### PR TITLE
fix(alert): don't use dynamic classes

### DIFF
--- a/packages/alert/src/component.tsx
+++ b/packages/alert/src/component.tsx
@@ -11,18 +11,21 @@ export function Alert({
   ...props
 }: PropsWithChildren<AlertProps>) {
 
+  const variantClasses = alert[type]
+  const iconVariantClasses = alert[`${type}Icon`]
+
   return (
     <ExpandTransition show={show}>
       <div
         role={role}
         className={classNames(
           props.className,
-          `flex p-16 border border-l-4 rounded-4 i-border-$color-alert-${type}-subtle-border i-bg-$color-alert-${type}-background i-text-$color-alert-${type}-text`,
+         `${alert.alert} ${variantClasses}`,
         )}
         style={{ borderLeftColor: `var(--w-color-alert-${type}-border)`, ...props.style }}
       >
         <div
-          className={`w-16 mr-8 pt-4 i-text-$color-alert-${type}-icon`}
+          className={`${alert.icon} ${iconVariantClasses}`}
           style={{ minWidth: '16px' }}
         >
           {iconMap[type]}
@@ -31,6 +34,21 @@ export function Alert({
       </div>
     </ExpandTransition>
   );
+}
+
+// TODO(@balbinak): export this from warp-ds/component-classes
+// TODO(@balbinak): add border-left-color token when fixed in warp-ds/drive
+const alert: Record<string, string> = {
+  alert: "flex p-16 border border-l-4 rounded-4",
+  icon: "w-16 mr-8 pt-4",
+  critical:  "i-border-$color-alert-critical-subtle-border i-bg-$color-alert-critical-background i-text-$color-alert-critical-text",
+  criticalIcon: "i-text-$color-alert-critical-icon",
+  success:  "i-border-$color-alert-success-subtle-border i-bg-$color-alert-success-background i-text-$color-alert-success-text",
+  successIcon: "i-text-$color-alert-success-icon",
+  warning:  "i-border-$color-alert-warning-subtle-border i-bg-$color-alert-warning-background i-text-$color-alert-warning-text",
+  warningIcon: "i-text-$color-alert-warning-icon",
+  info:  "i-border-$color-alert-info-subtle-border i-bg-$color-alert-info-background i-text-$color-alert-info-text",
+  infoIcon: "i-text-$color-alert-info-icon"
 }
 
 const iconMap: {


### PR DESCRIPTION
## Description
Fixes an issue mentioned in https://github.com/warp-ds/react/pull/5
> The automatic class factory doesn't work when trying to dynamically create the classes like using a prop in react for setting the type i-border-$color-alert-${type}-subtle-border...but it does work once I have used the class name hard coded before doing it dynamically, like i-border-$color-alert-success-subtle-border. Guessing that the css compiler has already run when the class gets set in react... 🤷

## Notes
The `alert` object will eventually be moved to https://github.com/warp-ds/component-classes but we might want to wait with that until border-left-color is applicable through a utility class so we can add it to the strings.

In a separate PR I will rename `critical` and `success` variants back to `negative` and `positive` to make it easier to revert those changes the future if we want those restored.

<img width="442" alt="Screenshot 2023-03-24 at 14 23 46" src="https://user-images.githubusercontent.com/41303231/227532830-d5566437-602b-4a0a-9ce7-346ae23c77cc.png">
