### PR TITLE
refactor(alert): style left border with semantic tokens

### DIFF
--- a/packages/alert/src/component.tsx
+++ b/packages/alert/src/component.tsx
@@ -22,7 +22,7 @@ export function Alert({
           props.className,
          `${alert.alert} ${variantClasses}`,
         )}
-        style={{ borderLeftColor: `var(--w-color-alert-${type}-border)`, ...props.style }}
+        style={props.style}
       >
         <div
           className={`${alert.icon} ${iconVariantClasses}`}
@@ -41,13 +41,13 @@ export function Alert({
 const alert: Record<string, string> = {
   alert: "flex p-16 border border-l-4 rounded-4",
   icon: "w-16 mr-8 pt-4",
-  negative:  "i-border-$color-alert-negative-subtle-border i-bg-$color-alert-negative-background i-text-$color-alert-negative-text",
+  negative:  "i-border-$color-alert-negative-subtle-border i-bg-$color-alert-negative-background i-text-$color-alert-negative-text i-border-l-$color-alert-negative-border",
   negativeIcon: "i-text-$color-alert-negative-icon",
-  positive:  "i-border-$color-alert-positive-subtle-border i-bg-$color-alert-positive-background i-text-$color-alert-positive-text",
+  positive:  "i-border-$color-alert-positive-subtle-border i-bg-$color-alert-positive-background i-text-$color-alert-positive-text i-border-l-$color-alert-positive-border",
   positiveIcon: "i-text-$color-alert-positive-icon",
-  warning:  "i-border-$color-alert-warning-subtle-border i-bg-$color-alert-warning-background i-text-$color-alert-warning-text",
+  warning:  "i-border-$color-alert-warning-subtle-border i-bg-$color-alert-warning-background i-text-$color-alert-warning-text i-border-l-$color-alert-warning-border",
   warningIcon: "i-text-$color-alert-warning-icon",
-  info:  "i-border-$color-alert-info-subtle-border i-bg-$color-alert-info-background i-text-$color-alert-info-text",
+  info:  "i-border-$color-alert-info-subtle-border i-bg-$color-alert-info-background i-text-$color-alert-info-text i-border-l-$color-alert-info-border",
   infoIcon: "i-text-$color-alert-info-icon"
 }
 


### PR DESCRIPTION
With @warp-ds/uno v.1.0.0-alpha.5 we got support for `i-border-l-$...` classes.

- [ ] tested that all border colors look correct