### PR TITLE
fix: remove common.css and use safelist

### DIFF
--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -25,9 +25,11 @@ module.exports = {
 
         const uno = (await import('@unocss/webpack'));
         const { presetWarp } = (await import('@warp-ds/uno'));
+        const { classes } = (await import('@warp-ds/component-classes/classes'));
 
         config.plugins.push(uno.default({
             presets: [presetWarp({ usePixels: true, usePreflight: true })],
+            safelist: classes,
         }));
         return config;
     },

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,2 +1,1 @@
 import 'uno.css';
-import '@warp-ds/component-classes/common';

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   },
   "dependencies": {
     "@chbphone55/classnames": "^2.0.0",
-    "@warp-ds/component-classes": "^1.0.0-alpha.9",
+    "@warp-ds/component-classes": "^1.0.0-alpha.13",
     "@warp-ds/core": "^1.0.0",
     "react-focus-lock": "^2.5.2",
     "resize-observer-polyfill": "^1.5.1",

--- a/packages/alert/src/component.tsx
+++ b/packages/alert/src/component.tsx
@@ -1,5 +1,6 @@
 import { classNames } from '@chbphone55/classnames';
 import React, { PropsWithChildren, ReactElement } from 'react';
+import { alert } from '@warp-ds/component-classes';
 import { AlertProps } from '.';
 import { ExpandTransition } from '../../_helpers';
 
@@ -34,21 +35,6 @@ export function Alert({
       </div>
     </ExpandTransition>
   );
-}
-
-// TODO(@balbinak): export this from warp-ds/component-classes
-// TODO(@balbinak): add border-left-color token when fixed in warp-ds/drive
-const alert: Record<string, string> = {
-  alert: "flex p-16 border border-l-4 rounded-4",
-  icon: "w-16 mr-8 pt-4",
-  negative:  "i-border-$color-alert-negative-subtle-border i-bg-$color-alert-negative-background i-text-$color-alert-negative-text i-border-l-$color-alert-negative-border",
-  negativeIcon: "i-text-$color-alert-negative-icon",
-  positive:  "i-border-$color-alert-positive-subtle-border i-bg-$color-alert-positive-background i-text-$color-alert-positive-text i-border-l-$color-alert-positive-border",
-  positiveIcon: "i-text-$color-alert-positive-icon",
-  warning:  "i-border-$color-alert-warning-subtle-border i-bg-$color-alert-warning-background i-text-$color-alert-warning-text i-border-l-$color-alert-warning-border",
-  warningIcon: "i-text-$color-alert-warning-icon",
-  info:  "i-border-$color-alert-info-subtle-border i-bg-$color-alert-info-background i-text-$color-alert-info-text i-border-l-$color-alert-info-border",
-  infoIcon: "i-text-$color-alert-info-icon"
 }
 
 const iconMap: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ specifiers:
   '@typescript-eslint/parser': ^4.14.1
   '@unocss/webpack': ^0.50.6
   '@vitejs/plugin-react-refresh': ^1.1.3
-  '@warp-ds/component-classes': ^1.0.0-alpha.9
+  '@warp-ds/component-classes': ^1.0.0-alpha.13
   '@warp-ds/core': ^1.0.0
   '@warp-ds/uno': ^1.0.0-alpha.5
   babel-eslint: ^10.1.0
@@ -63,7 +63,7 @@ specifiers:
 
 dependencies:
   '@chbphone55/classnames': 2.0.0
-  '@warp-ds/component-classes': 1.0.0-alpha.9
+  '@warp-ds/component-classes': 1.0.0-alpha.13
   '@warp-ds/core': 1.0.0
   react-focus-lock: 2.9.4_tujbw3i5d6amztjwlbeq7dljyy
   resize-observer-polyfill: 1.5.1
@@ -4079,8 +4079,8 @@ packages:
       - supports-color
     dev: true
 
-  /@warp-ds/component-classes/1.0.0-alpha.9:
-    resolution: {integrity: sha512-OwWLGTwdZp6u/9PEg5OhIfYtonS31zYMXnL1ResR9nmhL+cYB95MjhOecwwAnV3hrrJ2eFdjRhqArmFCxdFD+A==}
+  /@warp-ds/component-classes/1.0.0-alpha.13:
+    resolution: {integrity: sha512-p2TVRzhObUE/iTDtMx5WPfX7BXleNRbjSKwTD/kTgn6uv+/AdQkoXUV+4PxmZZaVgQdQ8TwlEnuOrzFkKmvxLg==}
     dev: false
 
   /@warp-ds/core/1.0.0:

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,7 @@ import jsxExample from './docs/src/plugins/jsxExample.cjs';
 import propTable from './docs/src/plugins/propTable.cjs';
 import { presetWarp } from '@warp-ds/uno'
 import uno from 'unocss/vite'
+import { classes } from '@warp-ds/component-classes/classes';
 
 
 export default function config() {
@@ -14,6 +15,7 @@ export default function config() {
     plugins: [
       uno({
         presets: [presetWarp({ usePixels: true, usePreflight: true })],
+        safelist: classes,
       }),
       reactRefresh(),
       mdx.default({


### PR DESCRIPTION
We encountered some problems with using common.css where warps uno css and common collided and classes got overriden(border vs border-l-4). Let's revert the usage of this css and revisit it later