### PR TITLE
fix: use updated component-classes in alert component

### DIFF
--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -28,7 +28,7 @@ module.exports = {
         const { classes } = (await import('@warp-ds/component-classes/classes'));
 
         config.plugins.push(uno.default({
-            presets: [presetWarp({ usePixels: true, usePreflight: true })],
+            presets: [presetWarp({ usePreflight: true })],
             safelist: classes,
         }));
         return config;

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   },
   "dependencies": {
     "@chbphone55/classnames": "^2.0.0",
-    "@warp-ds/component-classes": "^1.0.0-alpha.13",
+    "@warp-ds/component-classes": "^1.0.0-alpha.15",
     "@warp-ds/core": "^1.0.0",
     "react-focus-lock": "^2.5.2",
     "resize-observer-polyfill": "^1.5.1",

--- a/packages/alert/src/component.tsx
+++ b/packages/alert/src/component.tsx
@@ -27,11 +27,11 @@ export function Alert({
       >
         <div
           className={`${alert.icon} ${iconVariantClasses}`}
-          style={{ minWidth: '16px' }}
         >
           {iconMap[type]}
         </div>
-        <div className="last-child:mb-0 text-14">{children}</div>
+        {/* TODO: replace text-14 with a token */}
+        <div className="last:mb-0 text-14">{children}</div>
       </div>
     </ExpandTransition>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ specifiers:
   '@typescript-eslint/parser': ^4.14.1
   '@unocss/webpack': ^0.50.6
   '@vitejs/plugin-react-refresh': ^1.1.3
-  '@warp-ds/component-classes': ^1.0.0-alpha.13
+  '@warp-ds/component-classes': ^1.0.0-alpha.15
   '@warp-ds/core': ^1.0.0
   '@warp-ds/uno': ^1.0.0-alpha.5
   babel-eslint: ^10.1.0
@@ -63,7 +63,7 @@ specifiers:
 
 dependencies:
   '@chbphone55/classnames': 2.0.0
-  '@warp-ds/component-classes': 1.0.0-alpha.13
+  '@warp-ds/component-classes': 1.0.0-alpha.15
   '@warp-ds/core': 1.0.0
   react-focus-lock: 2.9.4_tujbw3i5d6amztjwlbeq7dljyy
   resize-observer-polyfill: 1.5.1
@@ -4079,8 +4079,8 @@ packages:
       - supports-color
     dev: true
 
-  /@warp-ds/component-classes/1.0.0-alpha.13:
-    resolution: {integrity: sha512-p2TVRzhObUE/iTDtMx5WPfX7BXleNRbjSKwTD/kTgn6uv+/AdQkoXUV+4PxmZZaVgQdQ8TwlEnuOrzFkKmvxLg==}
+  /@warp-ds/component-classes/1.0.0-alpha.15:
+    resolution: {integrity: sha512-bNxvVRDd6vRdhRABeCXH+O21Cb85RUUajg5CMVFoYnBlgEx9wjHrozHAW+oCYsOk+OspTGjJZw6V/U1dCJj3tw==}
     dev: false
 
   /@warp-ds/core/1.0.0:

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,7 +14,7 @@ export default function config() {
     // base: '/',
     plugins: [
       uno({
-        presets: [presetWarp({ usePixels: true, usePreflight: true })],
+        presets: [presetWarp({ usePreflight: true })],
         safelist: classes,
       }),
       reactRefresh(),


### PR DESCRIPTION
## Changes:
- bump `@warp-ds/component-classes` to `1.0.0-alpha.15` to apply updated styles to the alert icon ([changelog](https://github.com/warp-ds/component-classes/blob/alpha/CHANGELOG.md#100-alpha15-2023-04-05))
- fix class for controlling bottom margin of last child (`last-child:` was renamed to `last:` in @warp-ds/uno)
- don't use pixels in `presetWarp` as we want to default REM values when displaying Warp components. It will cause components to look a bit off compared to fabric components, but that's until we handle typography

<img width="456" alt="Screenshot 2023-04-05 at 10 41 34" src="https://user-images.githubusercontent.com/41303231/230028911-73d96489-ee70-48c2-860b-bb0d98e95d7b.png">
