### PR TITLE
fix: apply new tokens to textfield and textarea

### DIFF
--- a/docs/src/Main.tsx
+++ b/docs/src/Main.tsx
@@ -8,6 +8,9 @@ import {
 } from 'react-router-dom';
 import Alert from '../../packages/alert/docs/Alert.mdx';
 import Button from '../../packages/button/docs/Button.mdx';
+import TextField from '../../packages/textfield/docs/TextField.mdx';
+import TextArea from '../../packages/textarea/docs/TextArea.mdx';
+
 /*
 import Box from '../../packages/box/docs/Box.mdx';
 import Breadcrumbs from '../../packages/breadcrumbs/docs/Breadcrumbs.mdx';
@@ -21,8 +24,6 @@ import Slider from '../../packages/slider/docs/Slider.mdx';
 import Steps from '../../packages/steps/docs/Steps.mdx';
 import Switch from '../../packages/switch/docs/Switch.mdx';
 import Tabs from '../../packages/tabs/docs/Tabs.mdx';
-import TextArea from '../../packages/textarea/docs/TextArea.mdx';
-import TextField from '../../packages/textfield/docs/TextField.mdx';
 import Toggle from '../../packages/toggle/docs/Toggle.mdx';
 import Attention from '../../packages/attention/docs/Attention.mdx';
 */
@@ -58,6 +59,14 @@ const App = () => {
             <Button />
           </Route>
 
+          <Route path="/textfield">
+            <TextField />
+          </Route>
+
+          <Route path="/textarea">
+            <TextArea />
+          </Route>
+
           {/*
           <Route path="/modal">
             <Modal />
@@ -71,20 +80,12 @@ const App = () => {
             <Attention />
           </Route>
 
-          <Route path="/textfield">
-            <TextField />
-          </Route>
-
           <Route path="/select">
             <Select />
           </Route>
 
           <Route path="/tabs">
             <Tabs />
-          </Route>
-
-          <Route path="/textarea">
-            <TextArea />
           </Route>
 
           <Route path="/slider">

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   },
   "dependencies": {
     "@chbphone55/classnames": "^2.0.0",
-    "@warp-ds/component-classes": "^1.0.0-alpha.27",
+    "@warp-ds/component-classes": "^1.0.0-alpha.31",
     "@warp-ds/core": "^1.0.0",
     "react-focus-lock": "^2.5.2",
     "resize-observer-polyfill": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   },
   "dependencies": {
     "@chbphone55/classnames": "^2.0.0",
-    "@warp-ds/component-classes": "^1.0.0-alpha.31",
+    "@warp-ds/component-classes": "^1.0.0-alpha.32",
     "@warp-ds/core": "^1.0.0",
     "react-focus-lock": "^2.5.2",
     "resize-observer-polyfill": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@warp-ds/react",
   "version": "1.0.0-alpha.9",
   "repository": "git@github.com:warp-ds/react.git",
+  "type": "module",
   "license": "Apache-2.0",
   "exports": {
     ".": {
@@ -102,7 +103,7 @@
   },
   "dependencies": {
     "@chbphone55/classnames": "^2.0.0",
-    "@warp-ds/component-classes": "^1.0.0-alpha.15",
+    "@warp-ds/component-classes": "^1.0.0-alpha.16",
     "@warp-ds/core": "^1.0.0",
     "react-focus-lock": "^2.5.2",
     "resize-observer-polyfill": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   },
   "dependencies": {
     "@chbphone55/classnames": "^2.0.0",
-    "@warp-ds/component-classes": "^1.0.0-alpha.26",
+    "@warp-ds/component-classes": "^1.0.0-alpha.27",
     "@warp-ds/core": "^1.0.0",
     "react-focus-lock": "^2.5.2",
     "resize-observer-polyfill": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@warp-ds/react",
   "version": "1.0.0-alpha.9",
   "repository": "git@github.com:warp-ds/react.git",
-  "type": "module",
   "license": "Apache-2.0",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@warp-ds/react",
   "version": "1.0.0-alpha.9",
   "repository": "git@github.com:warp-ds/react.git",
-  "type": "module",
   "license": "Apache-2.0",
   "exports": {
     ".": {
@@ -103,7 +102,7 @@
   },
   "dependencies": {
     "@chbphone55/classnames": "^2.0.0",
-    "@warp-ds/component-classes": "^1.0.0-alpha.16",
+    "@warp-ds/component-classes": "^1.0.0-alpha.26",
     "@warp-ds/core": "^1.0.0",
     "react-focus-lock": "^2.5.2",
     "resize-observer-polyfill": "^1.5.1",

--- a/packages/_helpers/index.ts
+++ b/packages/_helpers/index.ts
@@ -1,5 +1,5 @@
 export { Clickable } from './clickable';
 export { DeadToggle } from './dead-toggle';
-/* export { Affix } from './affix'; */
+export { Affix } from './affix';
 export { ExpandTransition } from './expand-transition';
 export { UnstyledHeading } from './unstyled-heading';

--- a/packages/textarea/docs/TextArea.mdx
+++ b/packages/textarea/docs/TextArea.mdx
@@ -61,7 +61,7 @@ instead.
 Add the optional prop to indicate that the textarea is not required.
 
 ```jsx example
-<TextField label="Description" optional />
+<TextArea label="Description" optional />
 ```
 
 ## Help text

--- a/packages/textarea/src/component.tsx
+++ b/packages/textarea/src/component.tsx
@@ -39,27 +39,41 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       minimumRows,
     });
 
+    const input = {
+      default: 'block text-16 mb-0 leading-22 i-text-$color-input-text-filled i-bg-$color-input-background i-border-$color-input-border hover:i-border-$color-input-border-hover active:i-border-$color-input-border-active rounded-4 py-12 px-8 block border-1 w-full focusable',
+      optional: 'pl-8 font-normal text-14 i-text-$color-label-optional-text',
+      disabled: 'i-bg-$color-input-background-disabled i-border-$color-input-border-disabled i-text-$color-input-text-disabled pointer-events-none',
+      invalid: 'focusable i-border-$color-input-border-error i-text-$color-input-text-error',
+      readOnly: 'pl-0 bg-transparent border-0 pointer-events-none i-text-$color-input-text-read-only',
+      label: 'antialiased block relative text-14 font-bold pb-4 cursor-pointer',
+      labelValid: 'i-text-$color-label-text',
+      labelInvalid: 'i-text-$color-helptext-error-text',
+      helpText: 'text-12 mt-4 block',
+      helpTextValid: 'i-text-$color-helptext-text',
+      helpTextInvalid: 'i-text-$color-helptext-error-text'
+    }
+
     return (
       <div
-        className={classNames(className, {
-          'input mb-0': true,
-          'input--is-invalid': isInvalid,
-          'input--is-disabled': disabled,
-          'input--is-read-only': readOnly,
-        })}
         style={style}
       >
         {label && (
           <label htmlFor={id}>
             {label}
             {optional && (
-              <span className="pl-8 font-normal text-14 text-gray-500">
+              <span className={input.optional}>
                 (valgfritt)
               </span>
             )}
           </label>
         )}
         <textarea
+          className={classNames({
+            [input.default]: true,
+            [input.invalid]: isInvalid,
+            [input.disabled]: disabled,
+            [input.readOnly]: readOnly,
+          })}
           {...rest}
           aria-describedby={helpId}
           aria-errormessage={isInvalid && helpId ? helpId : undefined}
@@ -80,7 +94,13 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           readOnly={readOnly}
           value={value}
         />
-        {helpText && <div className="input__sub-text">{helpText}</div>}
+        {helpText && <div 
+          className={classNames({
+            [input.helpText]: true,
+            [input.helpTextValid]: !isInvalid,
+            [input.helpTextInvalid]: isInvalid
+          })}
+          >{helpText}</div>}
       </div>
     );
   },

--- a/packages/textarea/src/component.tsx
+++ b/packages/textarea/src/component.tsx
@@ -1,5 +1,6 @@
-import { classNames } from '@chbphone55/classnames';
 import React, { forwardRef, useRef } from 'react';
+import { classNames } from '@chbphone55/classnames';
+import { input } from '@warp-ds/component-classes';
 import { useId } from '../../utils/src';
 import { TextAreaProps } from './props';
 import useTextAreaHeight from './useTextAreaHeight';
@@ -38,20 +39,6 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       maximumRows,
       minimumRows,
     });
-
-    const input = {
-      default: 'block text-16 mb-0 leading-22 i-text-$color-input-text-filled i-bg-$color-input-background i-border-$color-input-border hover:i-border-$color-input-border-hover active:i-border-$color-input-border-active rounded-4 py-12 px-8 block border-1 w-full focusable',
-      optional: 'pl-8 font-normal text-14 i-text-$color-label-optional-text',
-      disabled: 'i-bg-$color-input-background-disabled i-border-$color-input-border-disabled i-text-$color-input-text-disabled pointer-events-none',
-      invalid: 'focusable i-border-$color-input-border-error i-text-$color-input-text-error',
-      readOnly: 'pl-0 bg-transparent border-0 pointer-events-none i-text-$color-input-text-read-only',
-      label: 'antialiased block relative text-14 font-bold pb-4 cursor-pointer',
-      labelValid: 'i-text-$color-label-text',
-      labelInvalid: 'i-text-$color-helptext-error-text',
-      helpText: 'text-12 mt-4 block',
-      helpTextValid: 'i-text-$color-helptext-text',
-      helpTextInvalid: 'i-text-$color-helptext-error-text'
-    }
 
     return (
       <div

--- a/packages/textarea/src/component.tsx
+++ b/packages/textarea/src/component.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useRef } from 'react';
 import { classNames } from '@chbphone55/classnames';
-import { input } from '@warp-ds/component-classes';
+import { input, helpText as h, label as l } from '@warp-ds/component-classes';
 import { useId } from '../../utils/src';
 import { TextAreaProps } from './props';
 import useTextAreaHeight from './useTextAreaHeight';
@@ -42,10 +42,15 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 
     return (
       <div
+        className={className}
         style={style}
       >
         {label && (
-          <label htmlFor={id}>
+          <label htmlFor={id} className={classNames({
+            [l.label]: true,
+            [l.labelValid]: !isInvalid,
+            [l.labelInvalid]: isInvalid
+          })} >
             {label}
             {optional && (
               <span className={input.optional}>
@@ -83,9 +88,9 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
         />
         {helpText && <div 
           className={classNames({
-            [input.helpText]: true,
-            [input.helpTextValid]: !isInvalid,
-            [input.helpTextInvalid]: isInvalid
+            [h.helpText]: true,
+            [h.helpTextValid]: !isInvalid,
+            [h.helpTextInvalid]: isInvalid
           })}
           >{helpText}</div>}
       </div>

--- a/packages/textarea/src/component.tsx
+++ b/packages/textarea/src/component.tsx
@@ -53,7 +53,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           })} >
             {label}
             {optional && (
-              <span className={input.optional}>
+              <span className={l.optional}>
                 (valgfritt)
               </span>
             )}
@@ -62,6 +62,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
         <textarea
           className={classNames({
             [input.default]: true,
+            [input.placeholder]: !!props.placeholder,
             [input.invalid]: isInvalid,
             [input.disabled]: disabled,
             [input.readOnly]: readOnly,
@@ -89,7 +90,6 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
         {helpText && <div 
           className={classNames({
             [h.helpText]: true,
-            [h.helpTextValid]: !isInvalid,
             [h.helpTextInvalid]: isInvalid
           })}
           >{helpText}</div>}

--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -1,5 +1,6 @@
-import { classNames } from '@chbphone55/classnames';
 import React, { forwardRef } from 'react';
+import { classNames } from '@chbphone55/classnames';
+import { input } from '@warp-ds/component-classes';
 import { useId } from '../../utils/src';
 import { TextFieldProps } from './props';
 
@@ -31,20 +32,6 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     const hasPrefix = React.Children.toArray(children).some(
       (child) => React.isValidElement(child) && child.props.prefix,
     );
-
-    const input = {
-      default: 'block text-16 mb-0 leading-22 i-text-$color-input-text-filled i-bg-$color-input-background i-border-$color-input-border hover:i-border-$color-input-border-hover active:i-border-$color-input-border-active rounded-4 py-12 px-8 block border-1 w-full focusable',
-      optional: 'pl-8 font-normal text-14 i-text-$color-label-optional-text',
-      disabled: 'i-bg-$color-input-background-disabled i-border-$color-input-border-disabled i-text-$color-input-text-disabled pointer-events-none',
-      invalid: 'focusable i-border-$color-input-border-error i-text-$color-input-text-error',
-      readOnly: 'pl-0 bg-transparent border-0 pointer-events-none i-text-$color-input-text-read-only',
-      label: 'antialiased block relative text-14 font-bold pb-4 cursor-pointer',
-      labelValid: 'i-text-$color-label-text',
-      labelInvalid: 'i-text-$color-helptext-error-text',
-      helpText: 'text-12 mt-4 block',
-      helpTextValid: 'i-text-$color-helptext-text',
-      helpTextInvalid: 'i-text-$color-helptext-error-text'
-    }
 
     return (
         <div>

--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -57,8 +57,8 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
               [input.disabled]: disabled,
               [input.readOnly]: readOnly,
               [input.placeholder]: !!props.placeholder,
-              'pr-40': hasSuffix,
-              'pl-40': hasPrefix,    
+              [input.suffix]: hasSuffix,
+              [input.prefix]: hasPrefix,    
             })}
               {...rest}
               aria-describedby={helpId}

--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react';
 import { classNames } from '@chbphone55/classnames';
-import { input } from '@warp-ds/component-classes';
+import { input, label as l, helpText as h } from '@warp-ds/component-classes';
 import { useId } from '../../utils/src';
 import { TextFieldProps } from './props';
 
@@ -37,9 +37,9 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         <div>
           {label && (
             <label htmlFor={id} className={classNames({
-              [input.label]: true,
-              [input.labelValid]: !isInvalid,
-              [input.labelInvalid]: isInvalid
+              [l.label]: true,
+              [l.labelValid]: !isInvalid,
+              [l.labelInvalid]: isInvalid
             })} >
               {label}
               {optional && (
@@ -74,9 +74,9 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
 
           {helpText && (
             <div className={classNames({
-              [input.helpText]: true,
-              [input.helpTextValid]: !isInvalid,
-              [input.helpTextInvalid]: isInvalid
+              [h.helpText]: true,
+              [h.helpTextValid]: !isInvalid,
+              [h.helpTextInvalid]: isInvalid
             })} id={helpId}>
               {helpText}
             </div>

--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -43,19 +43,20 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
             })} >
               {label}
               {optional && (
-                <span className={input.optional}>
+                <span className={l.optional}>
                   (valgfritt)
                 </span>
               )}
             </label>
           )}
-          <div className="relative">
+          <div className={input.wrapper}>
             <input
             className={classNames({
               [input.default]: true,
               [input.invalid]: isInvalid,
               [input.disabled]: disabled,
               [input.readOnly]: readOnly,
+              [input.placeholder]: !!props.placeholder,
               'pr-40': hasSuffix,
               'pl-40': hasPrefix,    
             })}
@@ -75,7 +76,6 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
           {helpText && (
             <div className={classNames({
               [h.helpText]: true,
-              [h.helpTextValid]: !isInvalid,
               [h.helpTextInvalid]: isInvalid
             })} id={helpId}>
               {helpText}

--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -32,26 +32,31 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       (child) => React.isValidElement(child) && child.props.prefix,
     );
 
+    const input = {
+      default: 'block text-16 mb-0 leading-22 i-text-$color-input-text-filled i-bg-$color-input-background i-border-$color-input-border hover:i-border-$color-input-border-hover active:i-border-$color-input-border-active rounded-4 py-12 px-8 block border-1 w-full focusable',
+      optional: 'pl-8 font-normal text-14 i-text-$color-label-optional-text',
+      disabled: 'i-bg-$color-input-background-disabled i-border-$color-input-border-disabled i-text-$color-input-text-disabled pointer-events-none',
+      invalid: 'focusable i-border-$color-input-border-error i-text-$color-input-text-error',
+      readOnly: 'pl-0 bg-transparent border-0 pointer-events-none i-text-$color-input-text-read-only',
+      label: 'antialiased block relative text-14 font-bold pb-4 cursor-pointer',
+      labelValid: 'i-text-$color-label-text',
+      labelInvalid: 'i-text-$color-helptext-error-text',
+      helpText: 'text-12 mt-4 block',
+      helpTextValid: 'i-text-$color-helptext-text',
+      helpTextInvalid: 'i-text-$color-helptext-error-text'
+    }
+
     return (
-      <div
-        className={classNames({
-          'has-suffix': hasSuffix,
-          'has-prefix': hasPrefix,
-        })}
-      >
-        <div
-          className={classNames({
-            'input mb-0': true,
-            'input--is-invalid': isInvalid,
-            'input--is-disabled': disabled,
-            'input--is-read-only': readOnly,
-          })}
-        >
+        <div>
           {label && (
-            <label htmlFor={id}>
+            <label htmlFor={id} className={classNames({
+              [input.label]: true,
+              [input.labelValid]: !isInvalid,
+              [input.labelInvalid]: isInvalid
+            })} >
               {label}
               {optional && (
-                <span className="pl-8 font-normal text-14 text-gray-500">
+                <span className={input.optional}>
                   (valgfritt)
                 </span>
               )}
@@ -59,6 +64,14 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
           )}
           <div className="relative">
             <input
+            className={classNames({
+              [input.default]: true,
+              [input.invalid]: isInvalid,
+              [input.disabled]: disabled,
+              [input.readOnly]: readOnly,
+              'pr-40': hasSuffix,
+              'pl-40': hasPrefix,    
+            })}
               {...rest}
               aria-describedby={helpId}
               aria-errormessage={isInvalid && helpId ? helpId : undefined}
@@ -73,12 +86,15 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
           </div>
 
           {helpText && (
-            <div className="input__sub-text" id={helpId}>
+            <div className={classNames({
+              [input.helpText]: true,
+              [input.helpTextValid]: !isInvalid,
+              [input.helpTextInvalid]: isInvalid
+            })} id={helpId}>
               {helpText}
             </div>
           )}
         </div>
-      </div>
     );
   },
 );

--- a/packages/textfield/stories/Textfield.stories.tsx
+++ b/packages/textfield/stories/Textfield.stories.tsx
@@ -28,7 +28,7 @@ export const placeholder = () => <TextField placeholder="Sesame street" />;
 
 export const disabled = () => <TextField disabled />;
 
-export const readOnly = () => <TextField readOnly />;
+export const readOnly = () => <TextField readOnly value="puse@finn.no" />;
 
 export const autoFocus = () => <TextField autoFocus />;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ specifiers:
   '@typescript-eslint/parser': ^4.14.1
   '@unocss/webpack': ^0.50.6
   '@vitejs/plugin-react-refresh': ^1.1.3
-  '@warp-ds/component-classes': ^1.0.0-alpha.27
+  '@warp-ds/component-classes': ^1.0.0-alpha.31
   '@warp-ds/core': ^1.0.0
   '@warp-ds/uno': ^1.0.0-alpha.5
   babel-eslint: ^10.1.0
@@ -63,7 +63,7 @@ specifiers:
 
 dependencies:
   '@chbphone55/classnames': 2.0.0
-  '@warp-ds/component-classes': 1.0.0-alpha.27
+  '@warp-ds/component-classes': 1.0.0-alpha.31
   '@warp-ds/core': 1.0.0
   react-focus-lock: 2.9.4_tujbw3i5d6amztjwlbeq7dljyy
   resize-observer-polyfill: 1.5.1
@@ -4079,8 +4079,8 @@ packages:
       - supports-color
     dev: true
 
-  /@warp-ds/component-classes/1.0.0-alpha.27:
-    resolution: {integrity: sha512-PPoRXDuORaxERm4aXpx+iassJwxMuFfU3olEnKGJHrQKyHrahFbgxRjA8ctG00Z5KVbKYJuo/ZoNz79vEhpDqQ==}
+  /@warp-ds/component-classes/1.0.0-alpha.31:
+    resolution: {integrity: sha512-gqoxHbj1YA4d8E6+9DAvPX1w0BwcJfx/P99IeBG9u/QXoHDsV9zl90B74qFCmw8Uei1n2pG25m2sOf/J5hRzXg==}
     dev: false
 
   /@warp-ds/core/1.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ specifiers:
   '@typescript-eslint/parser': ^4.14.1
   '@unocss/webpack': ^0.50.6
   '@vitejs/plugin-react-refresh': ^1.1.3
-  '@warp-ds/component-classes': ^1.0.0-alpha.16
+  '@warp-ds/component-classes': ^1.0.0-alpha.26
   '@warp-ds/core': ^1.0.0
   '@warp-ds/uno': ^1.0.0-alpha.5
   babel-eslint: ^10.1.0
@@ -63,7 +63,7 @@ specifiers:
 
 dependencies:
   '@chbphone55/classnames': 2.0.0
-  '@warp-ds/component-classes': 1.0.0-alpha.16
+  '@warp-ds/component-classes': 1.0.0-alpha.26
   '@warp-ds/core': 1.0.0
   react-focus-lock: 2.9.4_tujbw3i5d6amztjwlbeq7dljyy
   resize-observer-polyfill: 1.5.1
@@ -4079,8 +4079,8 @@ packages:
       - supports-color
     dev: true
 
-  /@warp-ds/component-classes/1.0.0-alpha.16:
-    resolution: {integrity: sha512-sUkBtzC7+AA8RKGMYyKKRyAhsI3BGOkLcW50TKd1SWgB/rwpARx68tOrNvzftqlHED6PFcxbBC5LxWChQvRxbw==}
+  /@warp-ds/component-classes/1.0.0-alpha.26:
+    resolution: {integrity: sha512-FM/YQvx4sS3E7Ui5OXrvpqygGmzqfOsSET45IXlN05PK0uNVnEhd++8z0jlstcG9PvGG8wLVJAT9+2oZvGCHJg==}
     dev: false
 
   /@warp-ds/core/1.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ specifiers:
   '@typescript-eslint/parser': ^4.14.1
   '@unocss/webpack': ^0.50.6
   '@vitejs/plugin-react-refresh': ^1.1.3
-  '@warp-ds/component-classes': ^1.0.0-alpha.31
+  '@warp-ds/component-classes': ^1.0.0-alpha.32
   '@warp-ds/core': ^1.0.0
   '@warp-ds/uno': ^1.0.0-alpha.5
   babel-eslint: ^10.1.0
@@ -63,7 +63,7 @@ specifiers:
 
 dependencies:
   '@chbphone55/classnames': 2.0.0
-  '@warp-ds/component-classes': 1.0.0-alpha.31
+  '@warp-ds/component-classes': 1.0.0-alpha.32
   '@warp-ds/core': 1.0.0
   react-focus-lock: 2.9.4_tujbw3i5d6amztjwlbeq7dljyy
   resize-observer-polyfill: 1.5.1
@@ -4079,8 +4079,8 @@ packages:
       - supports-color
     dev: true
 
-  /@warp-ds/component-classes/1.0.0-alpha.31:
-    resolution: {integrity: sha512-gqoxHbj1YA4d8E6+9DAvPX1w0BwcJfx/P99IeBG9u/QXoHDsV9zl90B74qFCmw8Uei1n2pG25m2sOf/J5hRzXg==}
+  /@warp-ds/component-classes/1.0.0-alpha.32:
+    resolution: {integrity: sha512-EeChnPiD+6HvJfm/8iMpUiD/h+cI36/bGnbrV6qvB7VNhTYunoNINMOfLaBOAJF1ENOExLjnMJP6D2HTr3AznQ==}
     dev: false
 
   /@warp-ds/core/1.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ specifiers:
   '@typescript-eslint/parser': ^4.14.1
   '@unocss/webpack': ^0.50.6
   '@vitejs/plugin-react-refresh': ^1.1.3
-  '@warp-ds/component-classes': ^1.0.0-alpha.15
+  '@warp-ds/component-classes': ^1.0.0-alpha.16
   '@warp-ds/core': ^1.0.0
   '@warp-ds/uno': ^1.0.0-alpha.5
   babel-eslint: ^10.1.0
@@ -63,7 +63,7 @@ specifiers:
 
 dependencies:
   '@chbphone55/classnames': 2.0.0
-  '@warp-ds/component-classes': 1.0.0-alpha.15
+  '@warp-ds/component-classes': 1.0.0-alpha.16
   '@warp-ds/core': 1.0.0
   react-focus-lock: 2.9.4_tujbw3i5d6amztjwlbeq7dljyy
   resize-observer-polyfill: 1.5.1
@@ -4079,8 +4079,8 @@ packages:
       - supports-color
     dev: true
 
-  /@warp-ds/component-classes/1.0.0-alpha.15:
-    resolution: {integrity: sha512-bNxvVRDd6vRdhRABeCXH+O21Cb85RUUajg5CMVFoYnBlgEx9wjHrozHAW+oCYsOk+OspTGjJZw6V/U1dCJj3tw==}
+  /@warp-ds/component-classes/1.0.0-alpha.16:
+    resolution: {integrity: sha512-sUkBtzC7+AA8RKGMYyKKRyAhsI3BGOkLcW50TKd1SWgB/rwpARx68tOrNvzftqlHED6PFcxbBC5LxWChQvRxbw==}
     dev: false
 
   /@warp-ds/core/1.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ specifiers:
   '@typescript-eslint/parser': ^4.14.1
   '@unocss/webpack': ^0.50.6
   '@vitejs/plugin-react-refresh': ^1.1.3
-  '@warp-ds/component-classes': ^1.0.0-alpha.26
+  '@warp-ds/component-classes': ^1.0.0-alpha.27
   '@warp-ds/core': ^1.0.0
   '@warp-ds/uno': ^1.0.0-alpha.5
   babel-eslint: ^10.1.0
@@ -63,7 +63,7 @@ specifiers:
 
 dependencies:
   '@chbphone55/classnames': 2.0.0
-  '@warp-ds/component-classes': 1.0.0-alpha.26
+  '@warp-ds/component-classes': 1.0.0-alpha.27
   '@warp-ds/core': 1.0.0
   react-focus-lock: 2.9.4_tujbw3i5d6amztjwlbeq7dljyy
   resize-observer-polyfill: 1.5.1
@@ -4079,8 +4079,8 @@ packages:
       - supports-color
     dev: true
 
-  /@warp-ds/component-classes/1.0.0-alpha.26:
-    resolution: {integrity: sha512-FM/YQvx4sS3E7Ui5OXrvpqygGmzqfOsSET45IXlN05PK0uNVnEhd++8z0jlstcG9PvGG8wLVJAT9+2oZvGCHJg==}
+  /@warp-ds/component-classes/1.0.0-alpha.27:
+    resolution: {integrity: sha512-PPoRXDuORaxERm4aXpx+iassJwxMuFfU3olEnKGJHrQKyHrahFbgxRjA8ctG00Z5KVbKYJuo/ZoNz79vEhpDqQ==}
     dev: false
 
   /@warp-ds/core/1.0.0:


### PR DESCRIPTION
Styles were migrated from https://github.com/fabric-ds/css/blob/49b07c05686ef132b203026e941bf04dbab6fc7a/src/components/form-elements.css

For testing in docs:
`http://localhost:3000/textarea`
`http://localhost:3000/textfield`
For testing in Storybook:
`http://localhost:9003/?path=/story/forms-textfield--standard` - check all types
`http://localhost:9003/?path=/story/forms-textarea--standard` - check all types

Design here: https://www.figma.com/file/8P1JQsd82b93gQ6K3igO2p/Warp---Component-library?node-id=393-38455&t=2Rt4QOodGYjj5KNF-0
Old docs: https://react.fabric-ds.io/textfield