### PR TITLE
fix: add component classes to select

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@warp-ds/react",
   "version": "1.0.0-alpha.14",
+  "type": "module",
   "repository": "git@github.com:warp-ds/react.git",
   "license": "Apache-2.0",
   "exports": {
@@ -100,7 +101,7 @@
   },
   "dependencies": {
     "@chbphone55/classnames": "^2.0.0",
-    "@warp-ds/component-classes": "^1.0.0-alpha.39",
+    "@warp-ds/component-classes": "^1.0.0-alpha.40",
     "@warp-ds/core": "^1.0.0",
     "react-focus-lock": "^2.5.2",
     "resize-observer-polyfill": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@typescript-eslint/parser": "^4.14.1",
     "@unocss/webpack": "^0.50.6",
     "@vitejs/plugin-react-refresh": "^1.1.3",
-    "@warp-ds/uno": "^1.0.0-alpha.5",
+    "@warp-ds/uno": "^1.0.0-alpha.8",
     "babel-eslint": "^10.1.0",
     "cz-conventional-changelog": "^3.3.0",
     "dotenv-webpack": "^7.1.0",
@@ -101,7 +101,7 @@
   },
   "dependencies": {
     "@chbphone55/classnames": "^2.0.0",
-    "@warp-ds/component-classes": "^1.0.0-alpha.36",
+    "@warp-ds/component-classes": "^1.0.0-alpha.37",
     "@warp-ds/core": "^1.0.0",
     "react-focus-lock": "^2.5.2",
     "resize-observer-polyfill": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@warp-ds/react",
   "version": "1.0.0-alpha.14",
-  "type": "module",
   "repository": "git@github.com:warp-ds/react.git",
   "license": "Apache-2.0",
   "exports": {
@@ -101,7 +100,7 @@
   },
   "dependencies": {
     "@chbphone55/classnames": "^2.0.0",
-    "@warp-ds/component-classes": "^1.0.0-alpha.37",
+    "@warp-ds/component-classes": "^1.0.0-alpha.39",
     "@warp-ds/core": "^1.0.0",
     "react-focus-lock": "^2.5.2",
     "resize-observer-polyfill": "^1.5.1",

--- a/packages/select/src/component.tsx
+++ b/packages/select/src/component.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { label as ccLabel, helpText as ccHelpText } from '@warp-ds/component-classes';
+import { select as ccSelect, label as ccLabel, helpText as ccHelpText } from '@warp-ds/component-classes';
 import { useId } from '../../utils/src';
 import { classNames } from '@chbphone55/classnames';
 import type { SelectProps } from './props';
@@ -20,19 +20,7 @@ const setup = (props) => {
   } = props;
 
   const helpId = hint ? `${id}__hint` : undefined;
-  const selectChevron = `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3E%3Cpath stroke='i-bg-$color-select-icon' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3E%3C/svg%3E")`;
 
-  const select = {
-    default: 'block text-16 mb-0 leading-22 i-text-$color-select-text i-bg-$color-select-background i-border-$color-select-border hover:i-border-$color-select-border-hover active:i-border-$color-select-border-active rounded-4 py-12 px-8 block border-1 w-full focusable appearance-none pr-32 cursor-pointer focus:caret',
-    disabled: 'i-bg-$color-select-background-disabled i-border-$color-select-border-disabled hover:i-border-$color-select-border-disabled! active:i-border-$color-select-border-disabled! i-text-$color-select-text-disabled pointer-events-none',
-    invalid: 'focusable i-border-$color-select-border-negative',
-    readOnly: 'pl-0 bg-transparent border-0 pointer-events-none before:hidden',
-    wrapper: 'relative',
-    wrap: `relative before:block before:absolute before:right-0 before:bottom-0 before:w-32 before:h-full before:content-[''] before:bg-[${selectChevron}] before:bg-no-repeat before:bg-center before:pointer-events-none `,
-    wrapDisabled: 'before:opacity-25',
-    chevron: 'absolute top-[30%] right-16',
-  }
-  
   return {
     attrs: {
       div: {
@@ -59,18 +47,17 @@ const setup = (props) => {
           : null,
     },
     classes: classNames({
-      [select.wrapper]: true,
+      [ccSelect.wrapper]: true,
       className
     }),
     selectClasses:  classNames({
-      [select.default]: true,
-      [select.invalid]: invalid,
-      [select.disabled]: disabled,
-      [select.readOnly]: readOnly
+      [ccSelect.default]: true,
+      [ccSelect.invalid]: invalid,
+      [ccSelect.disabled]: disabled,
+      [ccSelect.readOnly]: readOnly
     }),
     selectWrapClasses: classNames({
-      [select.wrap]: true,
-      [select.wrapDisabled]: disabled,
+      [ccSelect.selectWrapper]: true,
     }),
     helpTextClasses: classNames({
       [ccHelpText.helpText]: true,
@@ -82,7 +69,8 @@ const setup = (props) => {
       [ccLabel.labelInvalid]: invalid
     }),
     chevronClasses: classNames({
-      [select.chevron]: true
+      [ccSelect.chevron]: true,
+      [ccSelect.chevronDisabled]: disabled,
     })
   };
 };

--- a/packages/select/src/component.tsx
+++ b/packages/select/src/component.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { label as ccLabel, helpText as ccHelpText } from '@warp-ds/component-classes';
 import { useId } from '../../utils/src';
 import { classNames } from '@chbphone55/classnames';
 import type { SelectProps } from './props';
@@ -13,11 +14,25 @@ const setup = (props) => {
     label,
     style,
     optional,
+    readOnly,
+    disabled,
     ...rest
   } = props;
 
   const helpId = hint ? `${id}__hint` : undefined;
+  const selectChevron = `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3E%3Cpath stroke='i-bg-$color-select-icon' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3E%3C/svg%3E")`;
 
+  const select = {
+    default: 'block text-16 mb-0 leading-22 i-text-$color-select-text i-bg-$color-select-background i-border-$color-select-border hover:i-border-$color-select-border-hover active:i-border-$color-select-border-active rounded-4 py-12 px-8 block border-1 w-full focusable appearance-none pr-32 cursor-pointer focus:caret',
+    disabled: 'i-bg-$color-select-background-disabled i-border-$color-select-border-disabled hover:i-border-$color-select-border-disabled! active:i-border-$color-select-border-disabled! i-text-$color-select-text-disabled pointer-events-none',
+    invalid: 'focusable i-border-$color-select-border-negative',
+    readOnly: 'pl-0 bg-transparent border-0 pointer-events-none before:hidden',
+    wrapper: 'relative',
+    wrap: `relative before:block before:absolute before:right-0 before:bottom-0 before:w-32 before:h-full before:content-[''] before:bg-[${selectChevron}] before:bg-no-repeat before:bg-center before:pointer-events-none `,
+    wrapDisabled: 'before:opacity-25',
+    chevron: 'absolute top-[30%] right-16',
+  }
+  
   return {
     attrs: {
       div: {
@@ -43,37 +58,75 @@ const setup = (props) => {
             }
           : null,
     },
-    classes: classNames(
-      'input mb-0',
-      {
-        'input--is-invalid': invalid,
-      },
-      className,
-    ),
+    classes: classNames({
+      [select.wrapper]: true,
+      className
+    }),
+    selectClasses:  classNames({
+      [select.default]: true,
+      [select.invalid]: invalid,
+      [select.disabled]: disabled,
+      [select.readOnly]: readOnly
+    }),
+    selectWrapClasses: classNames({
+      [select.wrap]: true,
+      [select.wrapDisabled]: disabled,
+    }),
+    helpTextClasses: classNames({
+      [ccHelpText.helpText]: true,
+      [ccHelpText.helpTextInvalid]: invalid
+    }),
+    labelClasses: classNames({
+      [ccLabel.label]: true,
+      [ccLabel.labelValid]: !invalid,
+      [ccLabel.labelInvalid]: invalid
+    }),
+    chevronClasses: classNames({
+      [select.chevron]: true
+    })
   };
 };
 
 function Select(props: SelectProps, ref: React.Ref<HTMLSelectElement>) {
   const id = useId(props.id);
-  const { attrs, classes } = setup({ ...props, id });
+  const { attrs, classes, selectClasses, selectWrapClasses, helpTextClasses, labelClasses, chevronClasses } = setup({ ...props, id });
   const { div, label, select, help, optional } = attrs;
 
   return (
     <div className={classes} {...div}>
       {label.children && (
-        <label htmlFor={label.htmlFor}>
+        <label htmlFor={label.htmlFor} className={labelClasses}>
           {label.children}
           {optional && (
-            <span className="pl-8 font-normal text-14 text-gray-500">
+            <span className={ccLabel.optional}>
               (valgfritt)
             </span>
           )}
         </label>
       )}
-      <div className="input--select__wrap">
-        <select ref={ref} {...select} />
+      <div className={selectWrapClasses}>
+        <select ref={ref} {...select} className={selectClasses}/>
+          <div
+            className={classNames(chevronClasses)}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              fill="none"
+              viewBox="0 0 16 16"
+            >
+              <path
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.5"
+                d="M2.5 5.5L8 11L13.5 5.5"
+              />
+            </svg>
+          </div>
       </div>
-      {help && <div className="input__sub-text" {...help} />}
+      {help && <div className={helpTextClasses} {...help} />}
     </div>
   );
 }

--- a/packages/select/src/component.tsx
+++ b/packages/select/src/component.tsx
@@ -46,7 +46,7 @@ const setup = (props) => {
             }
           : null,
     },
-    classes: classNames({
+    wrapperClasses: classNames({
       [ccSelect.wrapper]: true,
       className
     }),
@@ -56,7 +56,7 @@ const setup = (props) => {
       [ccSelect.disabled]: disabled,
       [ccSelect.readOnly]: readOnly
     }),
-    selectWrapClasses: classNames({
+    selectWrapperClasses: classNames({
       [ccSelect.selectWrapper]: true,
     }),
     helpTextClasses: classNames({
@@ -65,7 +65,6 @@ const setup = (props) => {
     }),
     labelClasses: classNames({
       [ccLabel.label]: true,
-      [ccLabel.labelValid]: !invalid,
       [ccLabel.labelInvalid]: invalid
     }),
     chevronClasses: classNames({
@@ -77,11 +76,11 @@ const setup = (props) => {
 
 function Select(props: SelectProps, ref: React.Ref<HTMLSelectElement>) {
   const id = useId(props.id);
-  const { attrs, classes, selectClasses, selectWrapClasses, helpTextClasses, labelClasses, chevronClasses } = setup({ ...props, id });
+  const { attrs, wrapperClasses, selectClasses, selectWrapperClasses, helpTextClasses, labelClasses, chevronClasses } = setup({ ...props, id });
   const { div, label, select, help, optional } = attrs;
 
   return (
-    <div className={classes} {...div}>
+    <div className={wrapperClasses} {...div}>
       {label.children && (
         <label htmlFor={label.htmlFor} className={labelClasses}>
           {label.children}
@@ -92,7 +91,7 @@ function Select(props: SelectProps, ref: React.Ref<HTMLSelectElement>) {
           )}
         </label>
       )}
-      <div className={selectWrapClasses}>
+      <div className={selectWrapperClasses}>
         <select ref={ref} {...select} className={selectClasses}/>
           <div
             className={classNames(chevronClasses)}

--- a/packages/select/stories/Select.stories.tsx
+++ b/packages/select/stories/Select.stories.tsx
@@ -32,6 +32,13 @@ export const invalid = () => (
   </div>
 );
 
+export const disabled = () => (
+  <div className="flex flex-col space-y-32">
+    <Select disabled />
+    <Select disabled hint="Wrong choice" />
+  </div>
+);
+
 export const noLabel = () => (
   <div className="flex flex-col space-y-32">
     <WarpSelect

--- a/packages/textarea/src/component.tsx
+++ b/packages/textarea/src/component.tsx
@@ -49,7 +49,6 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
         {label && (
           <label htmlFor={id} className={classNames({
             [ccLabel.label]: true,
-            [ccLabel.labelValid]: !isInvalid,
             [ccLabel.labelInvalid]: isInvalid
           })} >
             {label}

--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -38,7 +38,6 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
           {label && (
             <label htmlFor={id} className={classNames({
               [ccLabel.label]: true,
-              [ccLabel.labelValid]: !isInvalid,
               [ccLabel.labelInvalid]: isInvalid
             })} >
               {label}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ dependencies:
     specifier: ^2.0.0
     version: 2.0.0
   '@warp-ds/component-classes':
-    specifier: ^1.0.0-alpha.39
-    version: 1.0.0-alpha.39
+    specifier: ^1.0.0-alpha.40
+    version: 1.0.0-alpha.40
   '@warp-ds/core':
     specifier: ^1.0.0
     version: 1.0.0
@@ -4136,8 +4136,8 @@ packages:
       - supports-color
     dev: true
 
-  /@warp-ds/component-classes@1.0.0-alpha.39:
-    resolution: {integrity: sha512-OtwQ+q/fsjRJIOjUSIe36d9rEwzSJ2E7vHLQaWodT4Y2uYpKR6YZpdd1vhMKLeJKQ5mvMjnEldww9+3XOAPSyA==}
+  /@warp-ds/component-classes@1.0.0-alpha.40:
+    resolution: {integrity: sha512-yGKY8XEVXQxmq4q8RqPTiXFv3a95WwNnot135ZDqz50/MaJPY1wpHsgKwvtapO6yy3OJ6CFh0c9klLiITAlxOw==}
     dev: false
 
   /@warp-ds/core@1.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ dependencies:
     specifier: ^2.0.0
     version: 2.0.0
   '@warp-ds/component-classes':
-    specifier: ^1.0.0-alpha.37
-    version: 1.0.0-alpha.37
+    specifier: ^1.0.0-alpha.39
+    version: 1.0.0-alpha.39
   '@warp-ds/core':
     specifier: ^1.0.0
     version: 1.0.0
@@ -4136,8 +4136,8 @@ packages:
       - supports-color
     dev: true
 
-  /@warp-ds/component-classes@1.0.0-alpha.37:
-    resolution: {integrity: sha512-5AgmbE7Nf/6t81Fj3YNM9pOJv5vgA+kAJ+eAqna//o6gm0kBdiOsoKUMxfwjkEhnVDujMh+jkrLEvFDAi1OcXw==}
+  /@warp-ds/component-classes@1.0.0-alpha.39:
+    resolution: {integrity: sha512-OtwQ+q/fsjRJIOjUSIe36d9rEwzSJ2E7vHLQaWodT4Y2uYpKR6YZpdd1vhMKLeJKQ5mvMjnEldww9+3XOAPSyA==}
     dev: false
 
   /@warp-ds/core@1.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ dependencies:
     specifier: ^2.0.0
     version: 2.0.0
   '@warp-ds/component-classes':
-    specifier: ^1.0.0-alpha.36
-    version: 1.0.0-alpha.36
+    specifier: ^1.0.0-alpha.37
+    version: 1.0.0-alpha.37
   '@warp-ds/core':
     specifier: ^1.0.0
     version: 1.0.0
@@ -79,8 +79,8 @@ devDependencies:
     specifier: ^1.1.3
     version: 1.3.6
   '@warp-ds/uno':
-    specifier: ^1.0.0-alpha.5
-    version: 1.0.0-alpha.5
+    specifier: ^1.0.0-alpha.8
+    version: 1.0.0-alpha.8
   babel-eslint:
     specifier: ^10.1.0
     version: 10.1.0(eslint@7.32.0)
@@ -4136,8 +4136,8 @@ packages:
       - supports-color
     dev: true
 
-  /@warp-ds/component-classes@1.0.0-alpha.36:
-    resolution: {integrity: sha512-p+q6b/lc/Ro75yGQJKTGI0Aa7bXWvvLeJXhu68Iq+0RZOmbC5DyVfHgMNjxG2WyLTzriAr/5TNs/SXaFVoEzsg==}
+  /@warp-ds/component-classes@1.0.0-alpha.37:
+    resolution: {integrity: sha512-5AgmbE7Nf/6t81Fj3YNM9pOJv5vgA+kAJ+eAqna//o6gm0kBdiOsoKUMxfwjkEhnVDujMh+jkrLEvFDAi1OcXw==}
     dev: false
 
   /@warp-ds/core@1.0.0:
@@ -4146,8 +4146,8 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/uno@1.0.0-alpha.5:
-    resolution: {integrity: sha512-8V6VuRmYujceUfYkbRkkQsu1EuLLQyRWfbLn9ehz962DXA+oJ4kSnjK12tdc2tNI/8EKs14Tl4c3X4e/d+1S/w==}
+  /@warp-ds/uno@1.0.0-alpha.8:
+    resolution: {integrity: sha512-OcrvcdtzlDtV+v1qTb6nLdK5xFdZNJDL3txYOvnNBXrmr7Jx7cmiMIRctZxkLsjSLA4HGVo5NlNWakHeWawSmw==}
     dependencies:
       '@unocss/core': 0.50.6
       '@unocss/preset-mini': 0.50.6


### PR DESCRIPTION
Migrated styling from https://github.com/fabric-ds/css/blob/49b07c05686ef132b203026e941bf04dbab6fc7a/src/components/form-elements.css

- Removed `labelValid` as it only was a color and is now a part of the default label styling

Variant|Screenshot
---|---
Standard | <img width="600" alt="image" src="https://user-images.githubusercontent.com/37986637/233102862-ec14c44d-4757-48b5-a2cf-ea1e7fc20ec6.png">
Hint | <img width="595" alt="image" src="https://user-images.githubusercontent.com/37986637/233102959-7457d024-f3bb-410b-afde-ef11d33d862a.png">
Invalid | <img width="599" alt="image" src="https://user-images.githubusercontent.com/37986637/233103055-dad1f531-7aed-4a1b-9bd7-5dfffa8367e8.png">
Disabled | <img width="630" alt="image" src="https://user-images.githubusercontent.com/37986637/233386445-4d3300a4-fa3d-48bc-9532-5e5fa7313a01.png">
No label | <img width="600" alt="image" src="https://user-images.githubusercontent.com/37986637/233103408-73eed912-ada2-4b68-8340-a60405279ee0.png">
Optional | <img width="595" alt="image" src="https://user-images.githubusercontent.com/37986637/233103490-2a4fb1ef-5ab6-4bf6-8e95-b1bdb67f6421.png">

