### PR TITLE
Add expandable component

### DIFF
--- a/docs/src/Main.tsx
+++ b/docs/src/Main.tsx
@@ -7,17 +7,17 @@ import {
   Switch as ReactSwitch,
 } from 'react-router-dom';
 import Alert from '../../packages/alert/docs/Alert.mdx';
-import Button from '../../packages/button/docs/Button.mdx';
-import TextField from '../../packages/textfield/docs/TextField.mdx';
-import TextArea from '../../packages/textarea/docs/TextArea.mdx';
 import Box from '../../packages/box/docs/Box.mdx';
+import Button from '../../packages/button/docs/Button.mdx';
+import Expandable from '../../packages/expandable/docs/Expandable.mdx';
+import TextArea from '../../packages/textarea/docs/TextArea.mdx';
+import TextField from '../../packages/textfield/docs/TextField.mdx';
 
 /*
 import Breadcrumbs from '../../packages/breadcrumbs/docs/Breadcrumbs.mdx';
 import Pill from '../../packages/pill/docs/Pill.mdx';
 import Card from '../../packages/card/docs/Card.mdx';
 import Combobox from '../../packages/combobox/docs/Combobox.mdx';
-import Expandable from '../../packages/expandable/docs/Expandable.mdx';
 import Modal from '../../packages/modal/docs/Modal.mdx';
 import Select from '../../packages/select/docs/Select.mdx';
 import Slider from '../../packages/slider/docs/Slider.mdx';
@@ -69,6 +69,10 @@ const App = () => {
 
           <Route path="/box">
             <Box />
+          </Route>
+
+          <Route path="/expandable">
+            <Expandable />
           </Route>
 
           {/*

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "dependencies": {
     "@chbphone55/classnames": "^2.0.0",
-    "@warp-ds/component-classes": "^1.0.0-alpha.38",
+    "@warp-ds/component-classes": "^1.0.0-alpha.39",
     "@warp-ds/core": "^1.0.0",
     "react-focus-lock": "^2.5.2",
     "resize-observer-polyfill": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@typescript-eslint/parser": "^4.14.1",
     "@unocss/webpack": "^0.50.6",
     "@vitejs/plugin-react-refresh": "^1.1.3",
-    "@warp-ds/uno": "^1.0.0-alpha.5",
+    "@warp-ds/uno": "^1.0.0-alpha.8",
     "babel-eslint": "^10.1.0",
     "cz-conventional-changelog": "^3.3.0",
     "dotenv-webpack": "^7.1.0",
@@ -101,7 +101,7 @@
   },
   "dependencies": {
     "@chbphone55/classnames": "^2.0.0",
-    "@warp-ds/component-classes": "^1.0.0-alpha.36",
+    "@warp-ds/component-classes": "^1.0.0-alpha.38",
     "@warp-ds/core": "^1.0.0",
     "react-focus-lock": "^2.5.2",
     "resize-observer-polyfill": "^1.5.1",

--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -1,7 +1,7 @@
 import { classNames } from '@chbphone55/classnames';
 import {
-  box as boxClasses,
-  buttonReset,
+  box as ccBox,
+  expandable as ccExpandable,
 } from '@warp-ds/component-classes';
 import React from 'react';
 import { ExpandTransition, UnstyledHeading } from '../../_helpers';
@@ -40,9 +40,9 @@ export function Expandable(props: ExpandableProps) {
     <div
       {...rest}
       className={classNames(className, {
-        'bg-aqua-50': info,
-        ['py-0 px-0 ' + boxClasses.box]: box,
-        [boxClasses.bleed]: bleed,
+        [ccExpandable.expandable]: true,
+        [ccExpandable.expandableBox]: box,
+        [ccExpandable.expandableBleed]: bleed,
       })}
     >
       <UnstyledHeading level={headingLevel}>
@@ -51,13 +51,12 @@ export function Expandable(props: ExpandableProps) {
           aria-expanded={stateExpanded}
           className={classNames({
             [buttonClass || '']: true,
-            [buttonReset + ' hover:underline focus:underline']: true,
-            ['w-full text-left relative ' + boxClasses.box]: box,
-            'hover:text-aqua-700 active:text-aqua-800': info,
+            [ccExpandable.button]: true,
+            [ccExpandable.buttonBox]: box,
           })}
           onClick={() => toggleExpandable(stateExpanded)}
         >
-          <div className="flex justify-between align-center">
+          <div className='flex justify-between align-center'>
             {typeof title === 'string' ? (
               <span className="h4">{title}</span>
             ) : (
@@ -66,10 +65,10 @@ export function Expandable(props: ExpandableProps) {
             {chevron && (
               <div
                 className={classNames({
-                  'self-center transform transition-transform': true,
-                  '-rotate-180': stateExpanded,
-                  'relative left-8': !box,
-                  'box-chevron': box,
+                  [ccExpandable.chevron]: true,
+                  [ccExpandable.chevronExpanded]: stateExpanded,
+                  [ccExpandable.chevronBox]: box,
+                  [ccExpandable.chevronNonBox]: !box,
                 })}
               >
                 <svg
@@ -96,7 +95,7 @@ export function Expandable(props: ExpandableProps) {
         <div
           className={classNames({
             [contentClass || '']: true,
-            [boxClasses.box + (title ? ' pt-0' : '')]: box,
+            [ccBox.box + (title ? ' pt-0' : '')]: box,
           })}
         >
           {children}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ dependencies:
     specifier: ^2.0.0
     version: 2.0.0
   '@warp-ds/component-classes':
-    specifier: ^1.0.0-alpha.36
-    version: 1.0.0-alpha.36
+    specifier: ^1.0.0-alpha.38
+    version: 1.0.0-alpha.38
   '@warp-ds/core':
     specifier: ^1.0.0
     version: 1.0.0
@@ -79,8 +79,8 @@ devDependencies:
     specifier: ^1.1.3
     version: 1.3.6
   '@warp-ds/uno':
-    specifier: ^1.0.0-alpha.5
-    version: 1.0.0-alpha.5
+    specifier: ^1.0.0-alpha.8
+    version: 1.0.0-alpha.8
   babel-eslint:
     specifier: ^10.1.0
     version: 10.1.0(eslint@7.32.0)
@@ -4136,8 +4136,8 @@ packages:
       - supports-color
     dev: true
 
-  /@warp-ds/component-classes@1.0.0-alpha.36:
-    resolution: {integrity: sha512-p+q6b/lc/Ro75yGQJKTGI0Aa7bXWvvLeJXhu68Iq+0RZOmbC5DyVfHgMNjxG2WyLTzriAr/5TNs/SXaFVoEzsg==}
+  /@warp-ds/component-classes@1.0.0-alpha.38:
+    resolution: {integrity: sha512-gA1Z2oGb/xTT1HzPuHzBWaakUb5hOugSNWqOU8Zda6tgbeAC262Mv1BuenRbrsCJGCNQkSmc7uzyqmvr+lMCQw==}
     dev: false
 
   /@warp-ds/core@1.0.0:
@@ -4146,8 +4146,8 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/uno@1.0.0-alpha.5:
-    resolution: {integrity: sha512-8V6VuRmYujceUfYkbRkkQsu1EuLLQyRWfbLn9ehz962DXA+oJ4kSnjK12tdc2tNI/8EKs14Tl4c3X4e/d+1S/w==}
+  /@warp-ds/uno@1.0.0-alpha.8:
+    resolution: {integrity: sha512-OcrvcdtzlDtV+v1qTb6nLdK5xFdZNJDL3txYOvnNBXrmr7Jx7cmiMIRctZxkLsjSLA4HGVo5NlNWakHeWawSmw==}
     dependencies:
       '@unocss/core': 0.50.6
       '@unocss/preset-mini': 0.50.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ dependencies:
     specifier: ^2.0.0
     version: 2.0.0
   '@warp-ds/component-classes':
-    specifier: ^1.0.0-alpha.38
-    version: 1.0.0-alpha.38
+    specifier: ^1.0.0-alpha.39
+    version: 1.0.0-alpha.39
   '@warp-ds/core':
     specifier: ^1.0.0
     version: 1.0.0
@@ -4136,8 +4136,8 @@ packages:
       - supports-color
     dev: true
 
-  /@warp-ds/component-classes@1.0.0-alpha.38:
-    resolution: {integrity: sha512-gA1Z2oGb/xTT1HzPuHzBWaakUb5hOugSNWqOU8Zda6tgbeAC262Mv1BuenRbrsCJGCNQkSmc7uzyqmvr+lMCQw==}
+  /@warp-ds/component-classes@1.0.0-alpha.39:
+    resolution: {integrity: sha512-OtwQ+q/fsjRJIOjUSIe36d9rEwzSJ2E7vHLQaWodT4Y2uYpKR6YZpdd1vhMKLeJKQ5mvMjnEldww9+3XOAPSyA==}
     dev: false
 
   /@warp-ds/core@1.0.0:


### PR DESCRIPTION
Expandable info box is no longer supported. The user can still pass info as a prop, but It will look like expandable box for now. 

Hover for expandable box should affect the background for the entire component: gray-50 -> gray-100, also when the component is expanded. 

<img width="391" alt="Screenshot 2023-04-19 at 13 42 03" src="https://user-images.githubusercontent.com/6739459/233103492-6a512f76-56ae-4802-94fa-9de529a79795.png">
