### PR TITLE
fix(packages): use className and style in TextField and Select

### DIFF
--- a/packages/select/src/component.tsx
+++ b/packages/select/src/component.tsx
@@ -46,10 +46,7 @@ const setup = (props) => {
             }
           : null,
     },
-    wrapperClasses: classNames({
-      [ccSelect.wrapper]: true,
-      className
-    }),
+    wrapperClasses: classNames(ccSelect.wrapper, className),
     selectClasses:  classNames({
       [ccSelect.default]: true,
       [ccSelect.invalid]: invalid,

--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -7,6 +7,7 @@ import { TextFieldProps } from './props';
 export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
   (props, ref) => {
     const {
+      className,
       disabled,
       id: providedId,
       children,
@@ -34,7 +35,10 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     );
 
     return (
-        <div>
+        <div 
+          className={className}
+          style={style}
+        >
           {label && (
             <label htmlFor={id} className={classNames({
               [ccLabel.label]: true,


### PR DESCRIPTION
Fixes an issue described [in this Slack thread](https://sch-chat.slack.com/archives/C04P0GYTHPV/p1686906779445769) where className set on `Select` or `TextField` would override the whole `className` prop of the `input` element.

Also added support for styling the whole component with `style` prop, as it seems to have been the strategy for other form components (Select, Textarea)