### PR TITLE
fix: use correct padding for small buttons

### DIFF
--- a/packages/button/src/component.tsx
+++ b/packages/button/src/component.tsx
@@ -39,7 +39,9 @@ export const Button = forwardRef<
     [ccButton.buttonUtilityFlat]: utility && quiet,
     // others
     [ccButton.buttonSmall]: small,
+    [ccButton.buttonSmallOverride]: small && !(secondary || utility),
     [ccButton.buttonUtility]: utility && !quiet,
+    [ccButton.buttonSmallUtility]: small && utility,
     [ccButton.buttonLink]: link,
     [ccButton.buttonPill]: pill,
     [ccButton.buttonInProgress]: loading,


### PR DESCRIPTION
**Issue**: different padding for small buttons for primary, negative and utility. The height should always be 32px (y padding 8 px) for small buttons including border. Might be better to use same padding for all small buttons and use `box-sizing: border-box` though 🤔 

**Solution:** use correct classes for small buttons.

```
buttonSmall: 'px-16 py-6 text-xs leading-xs', // .button--small
buttonSmallOverride: 'py-8', // .button--small.button--primary, .button--small.button--destructive, .button--small.button--destructive-flat, .button--small.button--order, .button--small.button--quiet
buttonSmallUtility: 'py-7 px-15', // .button--small.button--secondary
```
**Before (Fabric vs Warp):**
<img width="1168" alt="image" src="https://github.com/warp-ds/react/assets/5851332/3edc8454-efe7-4ded-9dc6-8d31674c4f7c">

**Now (react storybook):**
<img width="751" alt="image" src="https://github.com/warp-ds/react/assets/5851332/1da81eb3-bb41-4de8-937a-216da1ce04a9">
