### PR TITLE
fix: secondary button prop is not true by default

### DIFF
--- a/packages/button/src/props.tsx
+++ b/packages/button/src/props.tsx
@@ -29,8 +29,8 @@ export type ButtonProps = {
   primary?: boolean;
 
   /**
-   * Set the button to be a secondary, flat style button. Can be combined with `quiet` and `small`.
-   * @default true
+   * Set the button to be a secondary button. Can be combined with `quiet` and `small`.
+   * @default false
    */
   secondary?: boolean;
 


### PR DESCRIPTION
Background: https://sch-chat.slack.com/archives/C04P0GYTHPV/p1688384717329689

It is confusing that the prop is never true by default but the appearance is.