### PR TITLE
fix: stable FINN prod alpha-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   "dependencies": {
     "@chbphone55/classnames": "^2.0.0",
     "@warp-ds/uno": "^1.0.0-alpha.49",
-    "@warp-ds/component-classes": "^1.0.0-alpha.108",
+    "@warp-ds/component-classes": "^1.0.0-alpha.115",
     "@warp-ds/core": "^1.0.0",
     "react-focus-lock": "^2.5.2",
     "resize-observer-polyfill": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@typescript-eslint/eslint-plugin": "^4.14.1",
     "@typescript-eslint/parser": "^4.14.1",
     "@vitejs/plugin-react": "^4.0.0",
-    "@warp-ds/uno": "^1.0.0-alpha.47",
     "babel-eslint": "^10.1.0",
     "cz-conventional-changelog": "^3.3.0",
     "element-collapse": "^1.0.1",
@@ -104,6 +103,7 @@
   },
   "dependencies": {
     "@chbphone55/classnames": "^2.0.0",
+    "@warp-ds/uno": "^1.0.0-alpha.49",
     "@warp-ds/component-classes": "^1.0.0-alpha.108",
     "@warp-ds/core": "^1.0.0",
     "react-focus-lock": "^2.5.2",

--- a/packages/_helpers/clickable.tsx
+++ b/packages/_helpers/clickable.tsx
@@ -56,7 +56,7 @@ export function Clickable({
   return radio || checkbox ? (
     <ToggleItem
       labelClassName={classNames(props.labelClassName)}
-      className={`focus:focusable:focus focus-visible:focusable:focus-visible not-focus-visible:focusable:focus:not(:focus-visible) focusable-inset ${ccClickable.clickable}`} //TODO should be rewritten when fixed in drive, only `focusable` should be needed
+      className={ccClickable.toggle}
       type={type}
       controlled={false}
       onChange={props.onClick ? props.onClick : () => undefined}
@@ -70,11 +70,11 @@ export function Clickable({
       props.href ? 'a' : 'button',
       {
         ...props,
-        className: classNames(props.className, 'focus:focusable:focus focus:focusable:not(:focus-visible)'),
+        className: classNames(ccClickable.buttonOrLink, props.className),
         type: props.href ? undefined : props.type || 'button',
       },
       <>
-        <span className={ccClickable.clickableNotToggle} aria-hidden="true"></span>
+        <span className={ccClickable.buttonOrLinkStretch} aria-hidden="true"></span>
         {children}
       </>,
     )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -14,6 +14,9 @@ dependencies:
   '@warp-ds/core':
     specifier: ^1.0.0
     version: 1.0.0
+  '@warp-ds/uno':
+    specifier: ^1.0.0-alpha.49
+    version: 1.0.0-alpha.49
   react-focus-lock:
     specifier: ^2.5.2
     version: 2.9.4(@types/react@17.0.53)(react@16.14.0)
@@ -85,9 +88,6 @@ devDependencies:
   '@vitejs/plugin-react':
     specifier: ^4.0.0
     version: 4.0.0(vite@4.3.9)
-  '@warp-ds/uno':
-    specifier: ^1.0.0-alpha.47
-    version: 1.0.0-alpha.47
   babel-eslint:
     specifier: ^10.1.0
     version: 10.1.0(eslint@7.32.0)
@@ -5060,7 +5060,6 @@ packages:
 
   /@unocss/core@0.50.6:
     resolution: {integrity: sha512-WMIp8xr7YSlID2whqfRGLwagp59e6u4ckPACEpoDOW8sTeSPRZm54hxPhuWXD1SQuqcwHPMtM9nzGD8UOnqQxA==}
-    dev: true
 
   /@unocss/inspector@0.50.6:
     resolution: {integrity: sha512-6nX1YtaL67ohn/PfSSBv3npJ8qZcdc7S9X2zE6PUD/xhwtz7Bohx9I/KtmFdjJz5WeeGR7di0uYC6xsAcFLndQ==}
@@ -5103,7 +5102,6 @@ packages:
     resolution: {integrity: sha512-Ejgib688uvzCVgT/DHAOyXxKcM8vX55mxh8m3GAEx1H1pxg0IBfJO4QCKa3uAnasxj27XescBbvqv04dWi+jEQ==}
     dependencies:
       '@unocss/core': 0.50.6
-    dev: true
 
   /@unocss/preset-tagify@0.50.6:
     resolution: {integrity: sha512-ZyG/SJMobn4GZMbgrZOxT59ARp22LwgJGArCwJVosh3rraRVlb+B4x6ctMl6JOiLG5B1lHT9vZ92//u51Y0WTw==}
@@ -5234,12 +5232,12 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/uno@1.0.0-alpha.47:
-    resolution: {integrity: sha512-+8RGDnthKD5/FDGx+7/WdY0NsmGenTCfrPeHA+VoyFDrVgFxz+DiWn6SldayaeYVgjlmvXyKTVAn0leGZROXdQ==}
+  /@warp-ds/uno@1.0.0-alpha.49:
+    resolution: {integrity: sha512-72c5dT6QAy7GFmL+SN2gRlOsJWBWYM4uJpyw8WA9gCQHNENHXtoWu+D24+c47T9K908M3ZG+2+U1M/FXEZ7ojA==}
     dependencies:
       '@unocss/core': 0.50.6
       '@unocss/preset-mini': 0.50.6
-    dev: true
+    dev: false
 
   /@yarnpkg/esbuild-plugin-pnp@3.0.0-rc.15(esbuild@0.17.18):
     resolution: {integrity: sha512-kYzDJO5CA9sy+on/s2aIW0411AklfCi8Ck/4QDivOqsMKpStZA2SsR+X27VTggGwpStWaLrjJcDcdDMowtG8MA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^2.0.0
     version: 2.0.0
   '@warp-ds/component-classes':
-    specifier: ^1.0.0-alpha.108
-    version: 1.0.0-alpha.108
+    specifier: ^1.0.0-alpha.115
+    version: 1.0.0-alpha.115
   '@warp-ds/core':
     specifier: ^1.0.0
     version: 1.0.0
@@ -5222,8 +5222,8 @@ packages:
       - supports-color
     dev: true
 
-  /@warp-ds/component-classes@1.0.0-alpha.108:
-    resolution: {integrity: sha512-x2Aik7aQwNa2Ix4LOM6EkxONo26vvp70j0rxutT0w2st8ZRDMC/OdTkyx+3WxC6Yd6vL9VqWm7cJoVZomFgSiw==}
+  /@warp-ds/component-classes@1.0.0-alpha.115:
+    resolution: {integrity: sha512-+Gvds1oLj2Jj5WW5hwFCPts2K0L3/yQCCMg6io49QnZ0qDwd6whof3TkDg7emhqF+xEVh87r67bqLewZbOsnyg==}
     dev: false
 
   /@warp-ds/core@1.0.0:


### PR DESCRIPTION
## Background
With this setup @warp-ds/react will be compatible with [tokens](https://assets.finn.no/pkg/@warp-ds/tokens/v1/finn-no.css) currently available in FINN production. After merging this PR and so releasing a new alpha version, we will update [Warp Tech Docs](https://warp-ds.github.io/tech-docs/getting-started/developers/) and suggest the use of this particular version when relying on the above mentioned tokens.
 
## Changes
- bump `@warp-ds/uno` to `1.0.0.-alpha.49`
- bump `@warp-ds/component-classes` to `1.0.0.-alpha.115`

Also:
- Fix missing transparent background on buttons in Clickable, Tabs and Button of type "link"
- import classes for Clickable from component-classes