### PR TITLE
fix: trigger release of 1.0.0-alpha.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-# [1.0.0-alpha.38](https://github.com/warp-ds/react/compare/v1.0.0-alpha.37...v1.0.0-alpha.38) (2023-07-14)
-
-
-### Bug Fixes
-
-* use css packages instead of component-classes ([#55](https://github.com/warp-ds/react/issues/55)) ([64d45d3](https://github.com/warp-ds/react/commit/64d45d31872d7d13e52a0c91cf80ff949ecd4c33))
-
 # [1.0.0-alpha.37](https://github.com/warp-ds/react/compare/v1.0.0-alpha.36...v1.0.0-alpha.37) (2023-07-10)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@warp-ds/react",
-  "version": "1.0.0-alpha.38",
+  "version": "1.0.0-alpha.37",
   "type": "module",
   "repository": "git@github.com:warp-ds/react.git",
   "license": "Apache-2.0",


### PR DESCRIPTION
The release job failed in https://github.com/warp-ds/react/actions/runs/5552396928/jobs/10139700126 so we need to trigger it again by:
a) removing the 1.0.0-alpha.38 tag from https://github.com/warp-ds/react/tags
b) reverting the last semantic-release-bot commit: a8afe4e6582bae1c733530557f57baee94511236.
c) setting fix: prefix on the PR title to tell semantic-release we want our changes released.