### PR TITLE
fix(step): hide outer lines on horizontal variant of steps

### DIFF
--- a/packages/steps/src/step.tsx
+++ b/packages/steps/src/step.tsx
@@ -37,6 +37,7 @@ export function Step({ active, completed, children }: StepProps) {
 
   const stepLineHorizontalClasses = classNames({
     [ccStep.stepLine]: true,
+    [ccStep.stepLineHorizontalLeft]: true,
     [ccStep.stepLineHorizontal]: !vertical,
     [ccStep.stepLineIncomplete]: !active && !completed,
     [ccStep.stepLineComplete]: active || completed,
@@ -52,6 +53,7 @@ export function Step({ active, completed, children }: StepProps) {
 
   const stepLineClasses = classNames({
     [ccStep.stepLine]: true,
+    [ccStep.stepLineHorizontalRight]: true,
     [ccStep.stepLineVertical]: vertical,
     [ccStep.stepLineVerticalRight]: vertical && !left,
     [ccStep.stepLineHorizontal]: !vertical,


### PR DESCRIPTION
Fixes [WARP-128](https://nmp-jira.atlassian.net/browse/WARP-128)

Before:
<img width="728" alt="Screenshot 2023-08-01 at 09 51 17" src="https://github.com/warp-ds/react/assets/41303231/2605b0d4-437f-410e-a68b-b0b2b20dc9e4">

After:
<img width="733" alt="Screenshot 2023-08-01 at 09 50 56" src="https://github.com/warp-ds/react/assets/41303231/4bb7e7cd-0815-4355-9457-b9bad8d3a348">
