### PR TITLE
chore: set next as prerelease branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - alpha
       - beta
       - next
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,6 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
       - name: Eik login and publish
-        run: pnpm eik login -k $EIK_TOKEN && pnpm eik publish && pnpm eik pkg-alias || true
+        run: pnpm eik login -k $EIK_TOKEN && pnpm eik publish || true
         env:
           EIK_TOKEN: ${{ secrets.EIK_TOKEN }}

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -1,4 +1,4 @@
-name: Update alpha
+name: Update next
 on:
   workflow_run:
     workflows:
@@ -12,9 +12,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Rebase alpha to main
+      - name: Rebase next to main
         run: |
           git fetch --unshallow
-          git checkout alpha
+          git checkout next
           git rebase origin/main
           git push

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,6 @@
 {
   "branches": [
     { "name": "main" },
-    { "name": "alpha", "prerelease": true },
     { "name": "beta", "prerelease": true },
     { "name": "next", "prerelease": true }
   ],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ npm install -g pnpm
 Install dependencies by running:
 
 ```sh
-pnpm i
+pnpm install
 ```
 
 
@@ -69,11 +69,11 @@ pnpm docs:dev
 ### Branching
 
 There are two branches to keep in mind:
-- `alpha` : used for pre-releases.
+- `next` : default, used for pre-releases.
 - `main` : the main branch, used for stable releases.
 
 When adding a new feature, fixing a bug, or adding to the repository in any other way,
-you should always do this in a feature branch that is branched off the `alpha` branch.
+you should always do this in a feature branch that is branched off the `next` branch.
 
 ### Committing
 
@@ -82,10 +82,10 @@ as this is used in the [automated release process](#releases).
 
 ### Pull Request
 
-When your changes are ready for pull request, this should be opened against the `alpha` branch.
+When your changes are ready for pull request, this should be opened against the `next` branch.
 Add the [Warp Core Team](https://github.com/orgs/warp-ds/teams/warp-core-team) as reviewer.
 
-Pull request to the `alpha` branch should always be set to *squash*.
+Pull request to the `next` branch should always be set to *squash*.
 Make sure that the squash commit message follows the instructions in the [Committing](#committing) section before squash merging the pull request.
 
 ### Commitizen
@@ -106,22 +106,20 @@ When installed, you should be able to type `cz` or `git cz` in your terminal to 
 ## Releases
 
 This project uses [Semantic Release](https://github.com/semantic-release/semantic-release) to automate package
-publishing when making changes to the `main` or `alpha` branch.
+publishing when making changes to the `main` or `next` branch.
 
 Please note that the version published will depend on your commit message structure.
 Make sure to review and follow the instructions in the [Committing](#committing) section before committing.
 
-Before the first major release we develop against an `alpha` branch which is constantly published to [NPM](https://www.npmjs.com/package/@warp-ds/react) and [Eik]( ) using an `alpha` tag (e.g. `1.0.0-alpha.1`).
-Anyone needing to start using the package before the first major release can install the `alpha` version while waiting for the first stable version.
+This project is continuously published to [NPM](https://www.npmjs.com/package/@warp-ds/react) and [Eik](https://assets.finn.no/pkg/@warp-ds/react) using a `next` tag (e.g. `1.1.0-next.1`).
+Anyone needing to use the latest changes of this package can point to the `next` version while waiting for the stable release.
 
-TODO: When the first stable release is done, the `alpha` branch should possibly be renamed `next` to implement releasing a `next` tag from that branch instead of `alpha`.
+A stable release from the `main` branch is basically done by just opening a pull request from `next` to `main` and then make sure to _merge_ commit the pull request.
+Never squash to `main` to prevent losing history and commit messages from all commits to `next`.
 
-A stable release from the `main` branch is basically done by just opening a pull request from `alpha` to `main` and then make sure to *merge* commit the pull request.
-Never squash to `main` to prevent losing history and commit messages from all commits to `alpha`.
-
-To avoid git history divergence between `alpha` and `main`,
+To avoid git history divergence between `next` and `main`,
 when a stable release from `main` results in a semantic-release-bot commit being pushed to `main`,
-a GitHub action automatically rebase `alpha` to `origin/main` after every release from `main`.
+a GitHub action automatically rebase `next` to `origin/main` after every release from `main`.
 
 ( For reference, see this rfc in Fabric-ds: [RFC: Fabric Releases and Release Schedule](https://github.com/fabric-ds/issues/blob/779d59723993c13d62374516259602d967da56ca/rfcs/0004-releases.md) )
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install by using npm/pnpm or by adding a script link:
 
 #### Install using npm
 ```sh
-npm i -S @warp-ds/react
+npm install @warp-ds/react
 ```
 
 #### Install using pnpm
@@ -40,9 +40,8 @@ see the [Warp Design System documentation](https://warp-ds.github.io/tech-docs/)
 
 ## Releases
 
-This project is currently in alpha.
-Continuously published to [NPM](https://www.npmjs.com/package/@warp-ds/react) and [Eik](https://assets.finn.no/pkg/@warp-ds/react) using an `alpha` tag (e.g. `1.0.0-alpha.1`).
-Anyone needing to start using the package before the first major release can install the `alpha` version while waiting for the first stable version.
+This project is continuously published to [NPM](https://www.npmjs.com/package/@warp-ds/react) and [Eik](https://assets.finn.no/pkg/@warp-ds/react) using a `next` tag (e.g. `1.1.0-next.1`).
+Anyone needing to use the latest changes of this package can point to the `next` version while waiting for the stable release.
 
 
 ## Changelog


### PR DESCRIPTION
Changes included:
- update github workflows to use `next` instead of `alpha`
- update doc files to reflect the prerelease branch change

Also
- stop automatic updates of alias versions in Eik
- correct npm command in docs

- [x] !!! Update base branch to `next` before merging this PR (`next` must be branched off `master` after the major release PR is out)
- [x] Update branch settings to default to `next`
