### PR TITLE
fix: use new button classes and improve conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@chbphone55/classnames": "^2.0.0",
     "@lingui/core": "^4.3.0",
     "@warp-ds/core": "^1.0.0",
-    "@warp-ds/css": "^1.0.0",
+    "@warp-ds/css": "^1.0.1",
     "@warp-ds/uno": "^1.0.0",
     "react-focus-lock": "^2.5.2",
     "resize-observer-polyfill": "^1.5.1",

--- a/packages/button/src/component.tsx
+++ b/packages/button/src/component.tsx
@@ -3,14 +3,6 @@ import { button as ccButton } from '@warp-ds/css/component-classes';
 import { classNames } from '@chbphone55/classnames';
 import type { ButtonProps } from './props';
 
-const buttonTypes = [    
-  'primary',
-  'secondary',
-  'negative',
-  'utility',
-  'pill',
-  'link',
-] as const;
 export const Button = forwardRef<
   HTMLButtonElement | HTMLAnchorElement,
   ButtonProps
@@ -28,26 +20,31 @@ export const Button = forwardRef<
     ...rest
   } = props;
 
-  const buttonVariants = {
-    buttonInProgress:
-      'border-transparent! animate-inprogress i-text-$color-button-loading-text! pointer-events-none i-bg-$color-button-loading-background!', // .button--in-progress, a.button--in-progress:visited
-    buttonFlat:
-      'border-0! rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-bg-$color-button-quiet-background! i-text-$color-button-quiet-text! hover:i-bg-$color-button-quiet-background-hover! active:i-bg-$color-button-quiet-background-active!', // .button--quiet, .button--flat
-    buttonUtilityFlat: ' bg-transparent border-0 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-text-$color-button-utility-quiet-text i-bg-$color-button-utility-quiet-background hover:i-bg-$color-button-utility-quiet-background-hover rounded-4', // .button--utility.button--quiet, .button--flat
-    buttonDestructiveFlat: 'border-0 font-bold rounded-8 max-w-max focusable justify-center transition-colors ease-in-out i-bg-$color-button-negative-quiet-background! i-text-$color-button-negative-quiet-text! hover:i-bg-$color-button-negative-quiet-background-hover! active:i-bg-$color-button-negative-quiet-background-active!', // .button--utility.button--quiet, .button--flat
-    // Disabled
-    buttonIsDisabled:
-      'font-bold max-w-max justify-center transition-colors ease-in-out i-bg-$color-button-disabled-background! i-text-$color-button-disabled-text cursor-default pointer-events-none', // .button:disabled, .button--is-disabled
-  }
-  
+  const buttonStyling = {
+    default: 'font-bold max-w-max focusable justify-center transition-colors ease-in-out'
+  };
+
+  const buttonColors = {
+    primary: 'i-text-$color-button-primary-text hover:i-text-$color-button-primary-text i-bg-$color-button-primary-background hover:i-bg-$color-button-primary-background-hover active:i-bg-$color-button-primary-background-active',
+    secondary: 'i-text-$color-button-secondary-text hover:i-text-$color-button-secondary-text i-border-$color-button-secondary-border i-bg-$color-button-secondary-background hover:i-bg-$color-button-secondary-background-hover hover:i-border-$color-button-secondary-border-hover active:i-bg-$color-button-secondary-background-active',
+    utility: 'i-text-$color-button-utility-text hover:i-text-$color-button-utility-text i-bg-$color-button-utility-background i-border-$color-button-utility-border hover:i-bg-$color-button-utility-background hover:i-border-$color-button-utility-border-hover active:i-border-$color-button-utility-border-active',
+    destructive: 'i-bg-$color-button-negative-background i-text-$color-button-negative-text hover:i-text-$color-button-negative-text hover:i-bg-$color-button-negative-background-hover active:i-bg-$color-button-negative-background-active',
+    pill: 'i-text-$color-button-pill-icon hover:i-text-$color-button-pill-icon-hover active:i-text-$color-button-pill-icon-active i-bg-$color-button-pill-background hover:i-bg-$color-button-pill-background-hover active:i-bg-$color-button-pill-background-active',
+    disabled: 'i-text-$color-button-disabled-text i-bg-$color-button-disabled-background',
+    flat: 'i-bg-$color-button-quiet-background i-text-$color-button-quiet-text hover:i-bg-$color-button-quiet-background-hover active:i-bg-$color-button-quiet-background-active',
+    utilityFlat: 'i-text-$color-button-utility-quiet-text i-bg-$color-button-utility-quiet-background hover:i-bg-$color-button-utility-quiet-background-hover',
+    negativeFlat: 'i-bg-$color-button-negative-quiet-background i-text-$color-button-negative-quiet-text hover:i-bg-$color-button-negative-quiet-background-hover active:i-bg-$color-button-negative-quiet-background-active',
+    loading: '',
+  };
+
   const buttonTypes = {
-    primaryDefault: 'border-0 rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-text-$color-button-primary-text hover:i-text-$color-button-primary-text i-bg-$color-button-primary-background hover:i-bg-$color-button-primary-background-hover! active:i-bg-$color-button-primary-background-active',
-    secondaryDefault: 'border-2 rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-text-$color-button-secondary-text hover:i-text-$color-button-secondary-text i-border-$color-button-secondary-border i-bg-$color-button-secondary-background hover:i-bg-$color-button-secondary-background-hover hover:i-border-$color-button-secondary-border-hover active:i-bg-$color-button-secondary-background-active',
-    utilityDefault: 'font-bold max-w-max focusable justify-center transition-colors ease-in-out border rounded-4 i-text-$color-button-utility-text hover:i-text-$color-button-utility-text i-bg-$color-button-utility-background i-border-$color-button-utility-border hover:i-bg-$color-button-utility-background hover:i-border-$color-button-utility-border-hover! active:i-border-$color-button-utility-border-active!',
-    destructiveDefault: 'border-0 rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-bg-$color-button-negative-background i-text-$color-button-negative-text hover:i-text-$color-button-negative-text hover:i-bg-$color-button-negative-background-hover! active:i-bg-$color-button-negative-background-active!',
-    buttonPill:
-    'p-4 font-bold max-w-max focusable justify-center transition-colors ease-in-out rounded-full! border-0! i-text-$color-button-pill-icon hover:i-text-$color-button-pill-icon-hover active:i-text-$color-button-pill-icon-active i-bg-$color-button-pill-background hover:i-bg-$color-button-pill-background-hover active:i-bg-$color-button-pill-background-active inline-flex items-center justify-center hover:bg-clip-padding', // .button--pill
-    buttonLink: 'max-w-max bg-transparent focusable ease-in-out inline i-text-$color-button-link-text active:underline hover:underline', // .button--link
+    primary: `border-0 rounded-8 ${buttonStyling.default}`,
+    secondary: `border-2 rounded-8 ${buttonStyling.default}`,
+    utility: `border rounded-4 ${buttonStyling.default} ${buttonColors.utility}`,
+    negative: `border-0 rounded-8 ${buttonStyling.default}`,
+    pill:
+    `p-4 rounded-full border-0 inline-flex items-center justify-center hover:bg-clip-padding ${buttonStyling.default}`, // .button--pill
+    link: 'max-w-max bg-transparent focusable ease-in-out inline i-text-$color-button-link-text active:underline hover:underline', // .button--link
   }
 
   const buttonSizes = {
@@ -66,57 +63,77 @@ export const Button = forwardRef<
     xsmall: 'text-xs'
   }
 
+  const buttonVariants = {
+    // secondary: `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary}`,
+    buttonInProgress:
+      'border-transparent animate-inprogress pointer-events-none i-text-$color-button-loading-text i-bg-$color-button-loading-background', // .button--in-progress, a.button--in-progress:visited
+    buttonFlat:
+      `border-0 rounded-8 ${buttonStyling.default}`, // .button--quiet, .button--flat
+    buttonUtilityFlat: `bg-transparent border-0 rounded-4 ${buttonStyling.default}`, // .button--utility.button--quiet, .button--flat
+    negativeFlat: `border-0 rounded-8 ${buttonStyling.default}`, // .button--utility.button--quiet, .button--flat
+    // Disabled
+    buttonIsDisabled:
+      'font-bold max-w-max justify-center transition-colors ease-in-out cursor-default pointer-events-none', // .button:disabled, .button--is-disabled
+  }
   const ccButton = {
     // Buttontypes
     buttonSecondary:
-    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondaryDefault}`,
-    buttonSecondarySmall: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonTypes.secondaryDefault}`,
+    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary} ${buttonColors.secondary}`,
+    buttonSecondarySmall: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonTypes.secondary} ${buttonColors.secondary}`,
     buttonSecondaryQuiet:
-    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat}`,
-    buttonSecondarySmallQuiet: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonVariants.buttonFlat}`,
+    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat} ${buttonColors.flat}`,
+    buttonSecondarySmallQuiet: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonVariants.buttonFlat} ${buttonColors.flat}`,
     buttonSecondaryLoading:
-    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondaryDefault} ${buttonVariants.buttonInProgress}`,
-    buttonSecondarySmallLoading: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonTypes.secondaryDefault} ${buttonVariants.buttonInProgress}`,
+    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary} ${buttonVariants.buttonInProgress}`,
+    buttonSecondarySmallLoading: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonTypes.secondary} ${buttonVariants.buttonInProgress}`,
     buttonSecondarySmallQuietLoading: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonVariants.buttonFlat} ${buttonVariants.buttonInProgress}`,
     buttonSecondaryQuietLoading:
     `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat} ${buttonVariants.buttonInProgress}`,
-    buttonPrimary: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.primaryDefault}`,
-    buttonPrimaryQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat}`,
-    buttonPrimarySmall: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.primaryDefault}`,
-    buttonPrimarySmallQuiet: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonFlat}`,
-    buttonPrimaryLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.primaryDefault} ${buttonVariants.buttonInProgress}`,
-    buttonPrimarySmallLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.primaryDefault} ${buttonVariants.buttonInProgress}`,
+
+    buttonPrimary: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.primary} ${buttonColors.primary}`,
+    buttonPrimarySmall: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.primary} ${buttonColors.primary}`,
+    buttonPrimaryQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat} ${buttonColors.flat}`,
+    buttonPrimarySmallQuiet: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonFlat} ${buttonColors.flat}`,
+    buttonPrimaryLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonInProgress} ${buttonTypes.primary}`,
+    buttonPrimarySmallLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonInProgress} ${buttonTypes.primary}`,
+    buttonPrimarySmallQuietLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonFlat} ${buttonVariants.buttonInProgress} ${buttonTypes.primary}`,
     buttonPrimaryQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat} ${buttonVariants.buttonInProgress}`,
-    buttonPrimarySmallQuietLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonFlat} ${buttonVariants.buttonInProgress}`,
-    buttonUtility: `${buttonSizes.custom} ${buttonTextSizes.medium} ${buttonTypes.utilityDefault}`,
-    buttonUtilityQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonUtilityFlat}`,
-    buttonUtilitySmall: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.utilityDefault}`,
-    buttonUtilitySmallQuiet: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonUtilityFlat}`,
-    buttonUtilityLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.utilityDefault} ${buttonVariants.buttonInProgress}`,
-    buttonUtilitySmallLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.utilityDefault} ${buttonVariants.buttonInProgress}`,
-    buttonUtilityQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonUtilityFlat} ${buttonVariants.buttonInProgress}`,
-    buttonUtilitySmallQuietLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonUtilityFlat} ${buttonVariants.buttonInProgress}`,
-    buttonDestructive: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.destructiveDefault}`,
-    buttonDestructiveQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonDestructiveFlat}`,
-    buttonDestructiveSmall: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.destructiveDefault}`,
-    buttonDestructiveSmallQuiet: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonDestructiveFlat}`,
-    buttonDestructiveLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.destructiveDefault} ${buttonVariants.buttonInProgress}`,
-    buttonDestructiveSmallLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.destructiveDefault} ${buttonVariants.buttonInProgress}`,
-    buttonDestructiveQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonDestructiveFlat} ${buttonVariants.buttonInProgress}`,
-    buttonDestructiveSmallQuietLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonUtilityFlat} ${buttonVariants.buttonInProgress}`,
 
-    buttonPill: `${buttonSizes.pill} ${buttonTextSizes.medium} ${buttonTypes.buttonPill}`,
-    buttonPillSmall: `${buttonSizes.pillSmall} ${buttonTextSizes.xsmall} ${buttonTypes.buttonPill}`,
+    buttonUtility: `${buttonSizes.custom} ${buttonTextSizes.medium} ${buttonTypes.utility} ${buttonColors.utility}`,
+    buttonUtilityQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonUtilityFlat} ${buttonColors.utilityFlat}`,
+    buttonUtilitySmall: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.utility} ${buttonColors.utility}`,
+    buttonUtilitySmallQuiet: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonUtilityFlat} ${buttonColors.utilityFlat}`,
+    buttonUtilityLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.utility} ${buttonVariants.buttonInProgress}`,
+    buttonUtilitySmallLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.utility} ${buttonVariants.buttonInProgress}`,
+    buttonUtilityQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonInProgress} ${buttonVariants.buttonUtilityFlat}`,
+    buttonUtilitySmallQuietLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonInProgress} ${buttonVariants.buttonUtilityFlat}`,
 
-    buttonLink: `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.buttonLink}`,
-    buttonLinkSmall: `${buttonSizes.linkSmall} ${buttonTextSizes.xsmall} ${buttonTypes.buttonLink}`,
+    buttonNegative: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.negative} ${buttonColors.destructive}`,
+    buttonNegativeQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.negativeFlat} ${buttonColors.negativeFlat}`,
+    buttonNegativeSmall: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.negative} ${buttonColors.destructive}`,
+    buttonNegativeSmallQuiet: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.negativeFlat} ${buttonColors.negativeFlat}`,
+    buttonNegativeLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.negative} ${buttonVariants.buttonInProgress}`,
+    buttonNegativeSmallLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonInProgress} ${buttonTypes.negative}`,
+    buttonNegativeQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.negativeFlat} ${buttonTypes.negative} ${buttonVariants.buttonInProgress}`,
+    buttonNegativeSmallQuietLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.negativeFlat} ${buttonVariants.buttonInProgress}`,
+
+    pill: `${buttonSizes.pill} ${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonColors.pill}`,
+    pillSmall: `${buttonSizes.pillSmall} ${buttonTextSizes.xsmall} ${buttonTypes.pill} ${buttonColors.pill}`,
+    pillLoading: `${buttonSizes.pill} ${buttonTextSizes.medium} ${buttonTypes.pill}`,
+    pillSmallLoading: `${buttonSizes.pillSmall} ${buttonTextSizes.xsmall} ${buttonTypes.pill} ${buttonVariants.buttonInProgress}`,
+
+    link: `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.link}`,
+    linkSmall: `${buttonSizes.linkSmall} ${buttonTextSizes.xsmall} ${buttonTypes.link}`,
     linkAsButton: `${buttonSizes.medium} ${buttonTextSizes.medium} inline-block hover:no-underline`,
     buttonIsDisabled: buttonVariants.buttonIsDisabled,
     a11y: 'sr-only',
   };
 
+  const buttonType = Object.keys(buttonTypes).find(b => !!props[b]);
+  
   const classes = classNames(props.className, {
-    [ccButton.buttonSecondary]: secondary && !small && !quiet && !loading,
+    // [!loading && !props.disabled && buttonType ? buttonColors[buttonType] : (loading ? buttonColors.loading : buttonColors.disabled)]: true,
+    [ccButton.buttonSecondary]: (secondary || !buttonType) && !small && !quiet && !loading,
     [ccButton.buttonSecondarySmall]: secondary && small && !quiet && !loading,
     [ccButton.buttonSecondarySmallLoading]: secondary && small && !quiet && loading,
     [ccButton.buttonSecondarySmallQuiet]: secondary && small && quiet && !loading,
@@ -124,7 +141,7 @@ export const Button = forwardRef<
     [ccButton.buttonSecondaryQuiet]: secondary && !small && quiet && !loading,
     [ccButton.buttonSecondaryQuietLoading]: secondary && !small && quiet && loading,
     [ccButton.buttonSecondaryLoading]: secondary && !small && !quiet && loading,
-
+    
     [ccButton.buttonPrimary]: primary && !small && !quiet && !loading,
     [ccButton.buttonPrimarySmall]: primary && small && !quiet && !loading,
     [ccButton.buttonPrimarySmallQuiet]: primary && small && quiet && !loading,
@@ -143,20 +160,22 @@ export const Button = forwardRef<
     [ccButton.buttonUtilityQuietLoading]: utility && !small && quiet && loading,
     [ccButton.buttonUtilityLoading]: utility && !small && !quiet && loading,
 
-    [ccButton.buttonDestructive]: negative && !small && !quiet && !loading,
-    [ccButton.buttonDestructiveSmall]: negative && small && !quiet && !loading,
-    [ccButton.buttonDestructiveSmallQuiet]: negative && small && quiet && !loading,
-    [ccButton.buttonDestructiveSmallLoading]: negative && small && !quiet && loading,
-    [ccButton.buttonDestructiveSmallQuietLoading]: negative && small && quiet && loading,
-    [ccButton.buttonDestructiveQuiet]: negative && !small && quiet && !loading,
-    [ccButton.buttonDestructiveQuietLoading]: negative && !small && quiet && loading,
-    [ccButton.buttonDestructiveLoading]: negative && !small && !quiet && loading,
+    [ccButton.buttonNegative]: negative && !small && !quiet && !loading,
+    [ccButton.buttonNegativeSmall]: negative && small && !quiet && !loading,
+    [ccButton.buttonNegativeSmallQuiet]: negative && small && quiet && !loading,
+    [ccButton.buttonNegativeSmallLoading]: negative && small && !quiet && loading,
+    [ccButton.buttonNegativeSmallQuietLoading]: negative && small && quiet && loading,
+    [ccButton.buttonNegativeQuiet]: negative && !small && quiet && !loading,
+    [ccButton.buttonNegativeQuietLoading]: negative && !small && quiet && loading,
+    [ccButton.buttonNegativeLoading]: negative && !small && !quiet && loading,
 
-    [ccButton.buttonPill]: pill && !small,
-    [ccButton.buttonPillSmall]: pill && small,
-    [ccButton.buttonLink]: link && !small,
-    [ccButton.buttonLinkSmall]: link && small,
-    [ccButton.buttonIsDisabled]: props.disabled,
+    [ccButton.pill]: pill && !small && !loading,
+    [ccButton.pillSmall]: pill && small && !loading,
+    [ccButton.pillLoading]: pill && !small && loading,
+    [ccButton.pillSmallLoading]: pill && small && loading,
+    [ccButton.link]: link && !small,
+    [ccButton.linkSmall]: link && small,
+    // [ccButton.buttonIsDisabled]: props.disabled,
     [ccButton.linkAsButton]: !!props.href,
   });
 

--- a/packages/button/src/component.tsx
+++ b/packages/button/src/component.tsx
@@ -25,9 +25,7 @@ export const Button = forwardRef<
     ...rest
   } = props;
 
-  const buttonStyling = {
-    default: 'font-bold max-w-max focusable justify-center transition-colors ease-in-out'
-  };
+  const buttonDefaultStyling = 'font-bold max-w-max focusable justify-center transition-colors ease-in-out';
 
   const buttonColors = {
     primary: 'i-text-$color-button-primary-text hover:i-text-$color-button-primary-text i-bg-$color-button-primary-background hover:i-bg-$color-button-primary-background-hover active:i-bg-$color-button-primary-background-active',
@@ -36,20 +34,21 @@ export const Button = forwardRef<
     destructive: 'i-bg-$color-button-negative-background i-text-$color-button-negative-text hover:i-text-$color-button-negative-text hover:i-bg-$color-button-negative-background-hover active:i-bg-$color-button-negative-background-active',
     pill: 'i-text-$color-button-pill-icon hover:i-text-$color-button-pill-icon-hover active:i-text-$color-button-pill-icon-active i-bg-$color-button-pill-background hover:i-bg-$color-button-pill-background-hover active:i-bg-$color-button-pill-background-active',
     disabled: 'i-text-$color-button-disabled-text i-bg-$color-button-disabled-background',
-    flat: 'i-bg-$color-button-quiet-background i-text-$color-button-quiet-text hover:i-bg-$color-button-quiet-background-hover active:i-bg-$color-button-quiet-background-active',
-    utilityFlat: 'i-text-$color-button-utility-quiet-text i-bg-$color-button-utility-quiet-background hover:i-bg-$color-button-utility-quiet-background-hover',
-    negativeFlat: 'i-bg-$color-button-negative-quiet-background i-text-$color-button-negative-quiet-text hover:i-bg-$color-button-negative-quiet-background-hover active:i-bg-$color-button-negative-quiet-background-active',
-    loading: '',
+    quiet: 'i-bg-$color-button-quiet-background i-text-$color-button-quiet-text hover:i-bg-$color-button-quiet-background-hover active:i-bg-$color-button-quiet-background-active',
+    utilityQuiet: 'i-text-$color-button-utility-quiet-text i-bg-$color-button-utility-quiet-background hover:i-bg-$color-button-utility-quiet-background-hover',
+    negativeQuiet: 'i-bg-$color-button-negative-quiet-background i-text-$color-button-negative-quiet-text hover:i-bg-$color-button-negative-quiet-background-hover active:i-bg-$color-button-negative-quiet-background-active',
+    loading: 'i-text-$color-button-loading-text i-bg-$color-button-loading-background',
+    link: 'i-text-$color-button-link-text',
   };
 
   const buttonTypes = {
-    primary: `border-0 rounded-8 ${buttonStyling.default}`,
-    secondary: `border-2 rounded-8 ${buttonStyling.default}`,
-    utility: `border rounded-4 ${buttonStyling.default}`,
-    negative: `border-0 rounded-8 ${buttonStyling.default}`,
+    primary: `border-0 rounded-8 ${buttonDefaultStyling}`,
+    secondary: `border-2 rounded-8 ${buttonDefaultStyling}`,
+    utility: `border rounded-4 ${buttonDefaultStyling}`,
+    negative: `border-0 rounded-8 ${buttonDefaultStyling}`,
     pill:
-    `p-4 rounded-full border-0 inline-flex items-center justify-center hover:bg-clip-padding ${buttonStyling.default}`, // .button--pill
-    link: 'max-w-max bg-transparent focusable ease-in-out inline i-text-$color-button-link-text active:underline hover:underline', // .button--link
+    `p-4 rounded-full border-0 inline-flex items-center justify-center hover:bg-clip-padding ${buttonDefaultStyling}`, // .button--pill
+    link: `max-w-max bg-transparent focusable ease-in-out inline active:underline hover:underline ${buttonColors.link}`, // .button--link
   }
 
   const buttonSizes = {
@@ -70,144 +69,144 @@ export const Button = forwardRef<
   }
 
   const buttonVariants = {
-    buttonInProgress:
-      'border-transparent animate-inprogress pointer-events-none i-text-$color-button-loading-text i-bg-$color-button-loading-background', // .button--in-progress, a.button--in-progress:visited
-    buttonFlat:
-      `border-0 rounded-8 ${buttonStyling.default}`, // .button--quiet, .button--flat
-    buttonUtilityFlat: `bg-transparent border-0 rounded-4 ${buttonStyling.default}`, // .button--utility.button--quiet, .button--flat
-    negativeFlat: `border-0 rounded-8 ${buttonStyling.default}`, // .button--utility.button--quiet, .button--flat
+    inProgress:
+      `border-transparent animate-inprogress pointer-events-none ${buttonColors.loading}`, // .button--in-progress, a.button--in-progress:visited
+    quiet:
+      `border-0 rounded-8 ${buttonDefaultStyling}`, // .button--quiet, .button--flat
+    utilityQuiet: `bg-transparent border-0 rounded-4 ${buttonDefaultStyling}`, // .button--utility.button--quiet, .button--flat
+    negativeQuiet: `border-0 rounded-8 ${buttonDefaultStyling}`, // .button--utility.button--quiet, .button--flat
     // Disabled
-    buttonIsDisabled:
-      'font-bold max-w-max justify-center transition-colors ease-in-out cursor-default pointer-events-none i-text-$color-button-disabled-text i-bg-$color-button-disabled-background', // .button:disabled, .button--is-disabled
+    isDisabled:
+      `font-bold max-w-max justify-center transition-colors ease-in-out cursor-default pointer-events-none ${buttonColors.disabled}`, // .button:disabled, .button--is-disabled
   }
+
   const ccButton = {
     // Buttontypes
-    buttonSecondary:
+    secondary:
     `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary} ${buttonColors.secondary}`, // .button--secondary, .button--default, .button
-    buttonSecondaryHref:
+    secondaryHref:
     `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary} ${buttonColors.secondary}`, // .button--secondary, .button--default, .button
-    buttonSecondaryDisabled:
-    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary} ${buttonVariants.buttonIsDisabled}`,
-    buttonSecondarySmall: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonTypes.secondary} ${buttonColors.secondary}`,
-    buttonSecondarySmallDisabled: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonTypes.secondary} ${buttonVariants.buttonIsDisabled}`,
-    buttonSecondaryQuiet:
-    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat} ${buttonColors.flat}`,
-    buttonSecondaryQuietDisabled:
-    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat} ${buttonVariants.buttonIsDisabled}`,
-    buttonSecondarySmallQuiet: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonVariants.buttonFlat} ${buttonColors.flat}`,
-    buttonSecondarySmallQuietDisabled: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonVariants.buttonFlat} ${buttonVariants.buttonIsDisabled}`,
-    buttonSecondaryLoading:
-    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary} ${buttonVariants.buttonInProgress}`,
-    buttonSecondarySmallLoading: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonTypes.secondary} ${buttonVariants.buttonInProgress}`,
-    buttonSecondarySmallQuietLoading: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonVariants.buttonFlat} ${buttonVariants.buttonInProgress}`,
-    buttonSecondaryQuietLoading:
-    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat} ${buttonVariants.buttonInProgress}`,
+    secondaryDisabled:
+    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary} ${buttonVariants.isDisabled}`,
+    secondarySmall: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonTypes.secondary} ${buttonColors.secondary}`,
+    secondarySmallDisabled: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonTypes.secondary} ${buttonVariants.isDisabled}`,
+    secondaryQuiet:
+    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonVariants.quiet} ${buttonColors.quiet}`,
+    secondaryQuietDisabled:
+    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonVariants.quiet} ${buttonVariants.isDisabled}`,
+    secondarySmallQuiet: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonVariants.quiet} ${buttonColors.quiet}`,
+    secondarySmallQuietDisabled: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonVariants.quiet} ${buttonVariants.isDisabled}`,
+    secondaryLoading:
+    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary} ${buttonVariants.inProgress}`,
+    secondarySmallLoading: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall}  ${buttonTypes.secondary} ${buttonVariants.inProgress}`,
+    secondarySmallQuietLoading: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonVariants.quiet} ${buttonVariants.inProgress}`,
+    secondaryQuietLoading:
+    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonVariants.quiet} ${buttonVariants.inProgress}`,
 
-    buttonPrimary: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.primary} ${buttonColors.primary}`,
-    buttonPrimaryDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonIsDisabled} ${buttonTypes.primary}`,
-    buttonPrimarySmall: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.primary} ${buttonColors.primary}`,
-    buttonPrimarySmallDisabled: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonIsDisabled} ${buttonTypes.primary} `,
-    buttonPrimaryQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat} ${buttonColors.flat}`,
-    buttonPrimaryQuietDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat} ${buttonVariants.buttonIsDisabled}`,
-    buttonPrimarySmallQuiet: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonFlat} ${buttonColors.flat}`,
-    buttonPrimarySmallQuietDisabled: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonFlat} ${buttonVariants.buttonIsDisabled}`,
-    buttonPrimaryLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonInProgress} ${buttonTypes.primary}`,
-    buttonPrimarySmallLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonInProgress} ${buttonTypes.primary}`,
-    buttonPrimarySmallQuietLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonFlat} ${buttonVariants.buttonInProgress} ${buttonTypes.primary}`,
-    buttonPrimaryQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat} ${buttonVariants.buttonInProgress}`,
+    primary: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.primary} ${buttonColors.primary}`,
+    primaryDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.isDisabled} ${buttonTypes.primary}`,
+    primarySmall: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.primary} ${buttonColors.primary}`,
+    primarySmallDisabled: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.isDisabled} ${buttonTypes.primary} `,
+    primaryQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.quiet} ${buttonColors.quiet}`,
+    primaryQuietDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.quiet} ${buttonVariants.isDisabled}`,
+    primarySmallQuiet: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.quiet} ${buttonColors.quiet}`,
+    primarySmallQuietDisabled: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.quiet} ${buttonVariants.isDisabled}`,
+    primaryLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.inProgress} ${buttonTypes.primary}`,
+    primarySmallLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.inProgress} ${buttonTypes.primary} `,
+    primarySmallQuietLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.quiet} ${buttonVariants.inProgress} ${buttonTypes.primary}`,
+    primaryQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.quiet} ${buttonVariants.inProgress}`,
 
-    buttonUtility: `${buttonSizes.utility} ${buttonTextSizes.medium} ${buttonTypes.utility} ${buttonColors.utility}`,
-    buttonUtilityDisabled: `${buttonSizes.utility} ${buttonTextSizes.medium} ${buttonTypes.utility} ${buttonVariants.buttonIsDisabled}`,
-    buttonUtilityQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonUtilityFlat} ${buttonColors.utilityFlat}`,
-    buttonUtilityQuietDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonUtilityFlat} ${buttonVariants.buttonIsDisabled}`,
-    buttonUtilitySmall: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonTypes.utility} ${buttonColors.utility}`,
-    buttonUtilitySmallDisabled: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonTypes.utility} ${buttonVariants.buttonIsDisabled}`,
-    buttonUtilitySmallQuiet: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonVariants.buttonUtilityFlat} ${buttonColors.utilityFlat}`,
-    buttonUtilitySmallQuietDisabled: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonVariants.buttonUtilityFlat} ${buttonVariants.buttonIsDisabled}`,
-    buttonUtilityLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.utility} ${buttonVariants.buttonInProgress}`,
-    buttonUtilitySmallLoading: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonTypes.utility} ${buttonVariants.buttonInProgress}`,
-    buttonUtilityQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonInProgress} ${buttonVariants.buttonUtilityFlat}`,
-    buttonUtilitySmallQuietLoading: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonVariants.buttonInProgress} ${buttonVariants.buttonUtilityFlat}`,
+    utility: `${buttonSizes.utility} ${buttonTextSizes.medium} ${buttonTypes.utility} ${buttonColors.utility}`,
+    utilityDisabled: `${buttonSizes.utility} ${buttonTextSizes.medium} ${buttonTypes.utility} ${buttonVariants.isDisabled}`,
+    utilityQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.utilityQuiet} ${buttonColors.utilityQuiet}`,
+    utilityQuietDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.utilityQuiet} ${buttonVariants.isDisabled}`,
+    utilitySmall: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonTypes.utility} ${buttonColors.utility}`,
+    utilitySmallDisabled: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonTypes.utility} ${buttonVariants.isDisabled}`,
+    utilitySmallQuiet: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonVariants.utilityQuiet} ${buttonColors.utilityQuiet}`,
+    utilitySmallQuietDisabled: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonVariants.utilityQuiet} ${buttonVariants.isDisabled}`,
+    utilityLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.utility} ${buttonVariants.inProgress}`,
+    utilitySmallLoading: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonTypes.utility} ${buttonVariants.inProgress}`,
+    utilityQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.inProgress} ${buttonVariants.utilityQuiet}`,
+    utilitySmallQuietLoading: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonVariants.inProgress} ${buttonVariants.utilityQuiet}`,
 
-    buttonNegative: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.negative} ${buttonColors.destructive}`,
-    buttonNegativeDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.negative} ${buttonVariants.buttonIsDisabled}`,
-    buttonNegativeQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.negativeFlat} ${buttonColors.negativeFlat}`,
-    buttonNegativeQuietDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.negativeFlat}${buttonVariants.buttonIsDisabled}`,
-    buttonNegativeSmall: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.negative} ${buttonColors.destructive}`,
-    buttonNegativeSmallDisabled: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.negative} ${buttonVariants.buttonIsDisabled}`,
-    buttonNegativeSmallQuiet: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.negativeFlat} ${buttonColors.negativeFlat}`,
-    buttonNegativeSmallQuietDisabled: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.negativeFlat} ${buttonVariants.buttonIsDisabled}`,
-    buttonNegativeLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.negative} ${buttonVariants.buttonInProgress}`,
-    buttonNegativeSmallLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonInProgress} ${buttonTypes.negative}`,
-    buttonNegativeQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.negativeFlat} ${buttonTypes.negative} ${buttonVariants.buttonInProgress}`,
-    buttonNegativeSmallQuietLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.negativeFlat} ${buttonVariants.buttonInProgress}`,
+    negative: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.negative} ${buttonColors.destructive}`,
+    negativeDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.negative} ${buttonVariants.isDisabled}`,
+    negativeQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.negativeQuiet} ${buttonColors.negativeQuiet}`,
+    negativeQuietDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.negativeQuiet}${buttonVariants.isDisabled}`,
+    negativeSmall: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.negative} ${buttonColors.destructive}`,
+    negativeSmallDisabled: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.negative} ${buttonVariants.isDisabled}`,
+    negativeSmallQuiet: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.negativeQuiet} ${buttonColors.negativeQuiet}`,
+    negativeSmallQuietDisabled: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.negativeQuiet} ${buttonVariants.isDisabled}`,
+    negativeLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.negative} ${buttonVariants.inProgress}`,
+    negativeSmallLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.inProgress} ${buttonTypes.negative}`,
+    negativeQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.negativeQuiet} ${buttonTypes.negative} ${buttonVariants.inProgress}`,
+    negativeSmallQuietLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.negativeQuiet} ${buttonVariants.inProgress}`,
 
     pill: `${buttonSizes.pill} ${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonColors.pill}`,
     pillSmall: `${buttonSizes.pillSmall} ${buttonTextSizes.xsmall} ${buttonTypes.pill} ${buttonColors.pill}`,
-    pillLoading: `${buttonSizes.pill} ${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonVariants.buttonInProgress}`,
-    pillSmallLoading: `${buttonSizes.pillSmall} ${buttonTextSizes.xsmall} ${buttonTypes.pill} ${buttonVariants.buttonInProgress}`,
+    pillLoading: `${buttonSizes.pill} ${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonVariants.inProgress}`,
+    pillSmallLoading: `${buttonSizes.pillSmall} ${buttonTextSizes.xsmall} ${buttonTypes.pill} ${buttonVariants.inProgress}`,
 
     link: `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.link}`,
     linkSmall: `${buttonSizes.linkSmall} ${buttonTextSizes.xsmall} ${buttonTypes.link}`,
     linkAsButton: 'inline-block hover:no-underline',
-    buttonIsDisabled: buttonVariants.buttonIsDisabled,
     a11y: 'sr-only',
   };
 
   const buttonType = Object.keys(buttonTypes).find(b => !!props[b]);
   
   const classes = classNames(props.className, {
-    [ccButton.buttonSecondary]: (secondary || !buttonType) && !small && !quiet && !loading && !props.disabled,
-    [ccButton.buttonSecondaryDisabled]: (secondary || !buttonType) && !small && !quiet && !loading && props.disabled,
-    [ccButton.buttonSecondarySmall]: secondary && small && !quiet && !loading && !props.disabled,
-    [ccButton.buttonSecondarySmallDisabled]: secondary && small && !quiet && !loading && props.disabled,
-    [ccButton.buttonSecondarySmallLoading]: secondary && small && !quiet && loading,
-    [ccButton.buttonSecondarySmallQuiet]: secondary && small && quiet && !loading && !props.disabled,
-    [ccButton.buttonSecondarySmallQuietDisabled]: secondary && small && quiet && !loading && props.disabled,
-    [ccButton.buttonSecondarySmallQuietLoading]: secondary && small && quiet && loading,
-    [ccButton.buttonSecondaryQuiet]: secondary && !small && quiet && !loading && !props.disabled,
-    [ccButton.buttonSecondaryQuietDisabled]: secondary && !small && quiet && !loading && props.disabled,
-    [ccButton.buttonSecondaryQuietLoading]: secondary && !small && quiet && loading,
-    [ccButton.buttonSecondaryLoading]: secondary && !small && !quiet && loading,
+    [ccButton.secondary]: (secondary || !buttonType) && !small && !quiet && !loading && !props.disabled,
+    [ccButton.secondaryDisabled]: (secondary || !buttonType) && !small && !quiet && !loading && props.disabled,
+    [ccButton.secondarySmall]: secondary && small && !quiet && !loading && !props.disabled,
+    [ccButton.secondarySmallDisabled]: secondary && small && !quiet && !loading && props.disabled,
+    [ccButton.secondarySmallLoading]: secondary && small && !quiet && loading,
+    [ccButton.secondarySmallQuiet]: secondary && small && quiet && !loading && !props.disabled,
+    [ccButton.secondarySmallQuietDisabled]: secondary && small && quiet && !loading && props.disabled,
+    [ccButton.secondarySmallQuietLoading]: secondary && small && quiet && loading,
+    [ccButton.secondaryQuiet]: secondary && !small && quiet && !loading && !props.disabled,
+    [ccButton.secondaryQuietDisabled]: secondary && !small && quiet && !loading && props.disabled,
+    [ccButton.secondaryQuietLoading]: secondary && !small && quiet && loading,
+    [ccButton.secondaryLoading]: secondary && !small && !quiet && loading,
     
-    [ccButton.buttonPrimary]: primary && !small && !quiet && !loading && !props.disabled,
-    [ccButton.buttonPrimaryDisabled]: primary && !small && !quiet && !loading && props.disabled,
-    [ccButton.buttonPrimarySmall]: primary && small && !quiet && !loading && !props.disabled,
-    [ccButton.buttonPrimarySmallDisabled]: primary && small && !quiet && !loading && props.disabled,
-    [ccButton.buttonPrimarySmallQuiet]: primary && small && quiet && !loading && !props.disabled,
-    [ccButton.buttonPrimarySmallQuietDisabled]: primary && small && quiet && !loading && props.disabled,
-    [ccButton.buttonPrimarySmallLoading]: primary && small && !quiet && loading,
-    [ccButton.buttonPrimarySmallQuietLoading]: primary && small && quiet && loading,
-    [ccButton.buttonPrimaryQuiet]: primary && !small && quiet && !loading && !props.disabled,
-    [ccButton.buttonPrimaryQuietDisabled]: primary && !small && quiet && !loading && props.disabled,
-    [ccButton.buttonPrimaryQuietLoading]: primary && !small && quiet && loading,
-    [ccButton.buttonPrimaryLoading]: primary && !small && !quiet && loading,
+    [ccButton.primary]: primary && !small && !quiet && !loading && !props.disabled,
+    [ccButton.primaryDisabled]: primary && !small && !quiet && !loading && props.disabled,
+    [ccButton.primarySmall]: primary && small && !quiet && !loading && !props.disabled,
+    [ccButton.primarySmallDisabled]: primary && small && !quiet && !loading && props.disabled,
+    [ccButton.primarySmallQuiet]: primary && small && quiet && !loading && !props.disabled,
+    [ccButton.primarySmallQuietDisabled]: primary && small && quiet && !loading && props.disabled,
+    [ccButton.primarySmallLoading]: primary && small && !quiet && loading,
+    [ccButton.primarySmallQuietLoading]: primary && small && quiet && loading,
+    [ccButton.primaryQuiet]: primary && !small && quiet && !loading && !props.disabled,
+    [ccButton.primaryQuietDisabled]: primary && !small && quiet && !loading && props.disabled,
+    [ccButton.primaryQuietLoading]: primary && !small && quiet && loading,
+    [ccButton.primaryLoading]: primary && !small && !quiet && loading,
 
-    [ccButton.buttonUtility]: utility && !small && !quiet && !loading && !props.disabled,
-    [ccButton.buttonUtilityDisabled]: utility && !small && !quiet && !loading && props.disabled,
-    [ccButton.buttonUtilitySmall]: utility && small && !quiet && !loading && !props.disabled,
-    [ccButton.buttonUtilitySmallDisabled]: utility && small && !quiet && !loading && props.disabled,
-    [ccButton.buttonUtilitySmallQuiet]: utility && small && quiet && !loading && !props.disabled,
-    [ccButton.buttonUtilitySmallQuietDisabled]: utility && small && quiet && !loading && props.disabled,
-    [ccButton.buttonUtilitySmallLoading]: utility && small && !quiet && loading,
-    [ccButton.buttonUtilitySmallQuietLoading]: utility && small && quiet && loading,
-    [ccButton.buttonUtilityQuiet]: utility && !small && quiet && !loading && !props.disabled,
-    [ccButton.buttonUtilityQuietDisabled]: utility && !small && quiet && !loading && props.disabled,
-    [ccButton.buttonUtilityQuietLoading]: utility && !small && quiet && loading,
-    [ccButton.buttonUtilityLoading]: utility && !small && !quiet && loading,
+    [ccButton.utility]: utility && !small && !quiet && !loading && !props.disabled,
+    [ccButton.utilityDisabled]: utility && !small && !quiet && !loading && props.disabled,
+    [ccButton.utilitySmall]: utility && small && !quiet && !loading && !props.disabled,
+    [ccButton.utilitySmallDisabled]: utility && small && !quiet && !loading && props.disabled,
+    [ccButton.utilitySmallQuiet]: utility && small && quiet && !loading && !props.disabled,
+    [ccButton.utilitySmallQuietDisabled]: utility && small && quiet && !loading && props.disabled,
+    [ccButton.utilitySmallLoading]: utility && small && !quiet && loading,
+    [ccButton.utilitySmallQuietLoading]: utility && small && quiet && loading,
+    [ccButton.utilityQuiet]: utility && !small && quiet && !loading && !props.disabled,
+    [ccButton.utilityQuietDisabled]: utility && !small && quiet && !loading && props.disabled,
+    [ccButton.utilityQuietLoading]: utility && !small && quiet && loading,
+    [ccButton.utilityLoading]: utility && !small && !quiet && loading,
 
-    [ccButton.buttonNegative]: negative && !small && !quiet && !loading && !props.disabled,
-    [ccButton.buttonNegativeDisabled]: negative && !small && !quiet && !loading && props.disabled,
-    [ccButton.buttonNegativeSmall]: negative && small && !quiet && !loading && !props.disabled,
-    [ccButton.buttonNegativeSmallDisabled]: negative && small && !quiet && !loading && props.disabled,
-    [ccButton.buttonNegativeSmallQuiet]: negative && small && quiet && !loading && !props.disabled,
-    [ccButton.buttonNegativeSmallQuietDisabled]: negative && small && quiet && !loading && props.disabled,
-    [ccButton.buttonNegativeSmallLoading]: negative && small && !quiet && loading,
-    [ccButton.buttonNegativeSmallQuietLoading]: negative && small && quiet && loading,
-    [ccButton.buttonNegativeQuiet]: negative && !small && quiet && !loading && !props.disabled,
-    [ccButton.buttonNegativeQuietDisabled]: negative && !small && quiet && !loading && props.disabled,
-    [ccButton.buttonNegativeQuietLoading]: negative && !small && quiet && loading,
-    [ccButton.buttonNegativeLoading]: negative && !small && !quiet && loading,
+    [ccButton.negative]: negative && !small && !quiet && !loading && !props.disabled,
+    [ccButton.negativeDisabled]: negative && !small && !quiet && !loading && props.disabled,
+    [ccButton.negativeSmall]: negative && small && !quiet && !loading && !props.disabled,
+    [ccButton.negativeSmallDisabled]: negative && small && !quiet && !loading && props.disabled,
+    [ccButton.negativeSmallQuiet]: negative && small && quiet && !loading && !props.disabled,
+    [ccButton.negativeSmallQuietDisabled]: negative && small && quiet && !loading && props.disabled,
+    [ccButton.negativeSmallLoading]: negative && small && !quiet && loading,
+    [ccButton.negativeSmallQuietLoading]: negative && small && quiet && loading,
+    [ccButton.negativeQuiet]: negative && !small && quiet && !loading && !props.disabled,
+    [ccButton.negativeQuietDisabled]: negative && !small && quiet && !loading && props.disabled,
+    [ccButton.negativeQuietLoading]: negative && !small && quiet && loading,
+    [ccButton.negativeLoading]: negative && !small && !quiet && loading,
 
     [ccButton.pill]: pill && !small && !loading,
     [ccButton.pillSmall]: pill && small && !loading,

--- a/packages/button/src/component.tsx
+++ b/packages/button/src/component.tsx
@@ -119,7 +119,7 @@ export const Button = forwardRef<
 
     pill: `${buttonSizes.pill} ${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonColors.pill}`,
     pillSmall: `${buttonSizes.pillSmall} ${buttonTextSizes.xsmall} ${buttonTypes.pill} ${buttonColors.pill}`,
-    pillLoading: `${buttonSizes.pill} ${buttonTextSizes.medium} ${buttonTypes.pill}`,
+    pillLoading: `${buttonSizes.pill} ${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonVariants.buttonInProgress}`,
     pillSmallLoading: `${buttonSizes.pillSmall} ${buttonTextSizes.xsmall} ${buttonTypes.pill} ${buttonVariants.buttonInProgress}`,
 
     link: `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.link}`,

--- a/packages/button/src/component.tsx
+++ b/packages/button/src/component.tsx
@@ -32,48 +32,86 @@ export const Button = forwardRef<
     buttonInProgress:
       'border-transparent! animate-inprogress i-text-$color-button-loading-text! pointer-events-none i-bg-$color-button-loading-background!', // .button--in-progress, a.button--in-progress:visited
     buttonFlat:
-      'border-0!  rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-bg-$color-button-quiet-background! i-text-$color-button-quiet-text! hover:i-bg-$color-button-quiet-background-hover! active:i-bg-$color-button-quiet-background-active!', // .button--quiet, .button--flat
+      'border-0! rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-bg-$color-button-quiet-background! i-text-$color-button-quiet-text! hover:i-bg-$color-button-quiet-background-hover! active:i-bg-$color-button-quiet-background-active!', // .button--quiet, .button--flat
+    buttonUtilityFlat: ' bg-transparent border-0 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-text-$color-button-utility-quiet-text i-bg-$color-button-utility-quiet-background hover:i-bg-$color-button-utility-quiet-background-hover rounded-4', // .button--utility.button--quiet, .button--flat
+    buttonDestructiveFlat: 'border-0 font-bold rounded-8 max-w-max focusable justify-center transition-colors ease-in-out i-bg-$color-button-negative-quiet-background! i-text-$color-button-negative-quiet-text! hover:i-bg-$color-button-negative-quiet-background-hover! active:i-bg-$color-button-negative-quiet-background-active!', // .button--utility.button--quiet, .button--flat
     // Disabled
     buttonIsDisabled:
       'font-bold max-w-max justify-center transition-colors ease-in-out i-bg-$color-button-disabled-background! i-text-$color-button-disabled-text cursor-default pointer-events-none', // .button:disabled, .button--is-disabled
-    primaryDefault: 'border-0 rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-text-$color-button-primary-text hover:i-text-$color-button-primary-text i-bg-$color-button-primary-background hover:i-bg-$color-button-primary-background-hover! active:i-bg-$color-button-primary-background-active',
-    secondaryDefault: 'border-2 font-bold rounded-8 max-w-max focusable justify-center transition-colors ease-in-out i-text-$color-button-secondary-text hover:i-text-$color-button-secondary-text i-border-$color-button-secondary-border i-bg-$color-button-secondary-background hover:i-bg-$color-button-secondary-background-hover hover:i-border-$color-button-secondary-border-hover active:i-bg-$color-button-secondary-background-active'
   }
-    
+  
+  const buttonTypes = {
+    primaryDefault: 'border-0 rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-text-$color-button-primary-text hover:i-text-$color-button-primary-text i-bg-$color-button-primary-background hover:i-bg-$color-button-primary-background-hover! active:i-bg-$color-button-primary-background-active',
+    secondaryDefault: 'border-2 rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-text-$color-button-secondary-text hover:i-text-$color-button-secondary-text i-border-$color-button-secondary-border i-bg-$color-button-secondary-background hover:i-bg-$color-button-secondary-background-hover hover:i-border-$color-button-secondary-border-hover active:i-bg-$color-button-secondary-background-active',
+    utilityDefault: 'font-bold max-w-max focusable justify-center transition-colors ease-in-out border rounded-4 i-text-$color-button-utility-text hover:i-text-$color-button-utility-text i-bg-$color-button-utility-background i-border-$color-button-utility-border hover:i-bg-$color-button-utility-background hover:i-border-$color-button-utility-border-hover! active:i-border-$color-button-utility-border-active!',
+    destructiveDefault: 'border-0 rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-bg-$color-button-negative-background i-text-$color-button-negative-text hover:i-text-$color-button-negative-text hover:i-bg-$color-button-negative-background-hover! active:i-bg-$color-button-negative-background-active!',
+    buttonPill:
+    'p-4 font-bold max-w-max focusable justify-center transition-colors ease-in-out rounded-full! border-0! i-text-$color-button-pill-icon hover:i-text-$color-button-pill-icon-hover active:i-text-$color-button-pill-icon-active i-bg-$color-button-pill-background hover:i-bg-$color-button-pill-background-hover active:i-bg-$color-button-pill-background-active inline-flex items-center justify-center hover:bg-clip-padding', // .button--pill
+    buttonLink: 'max-w-max bg-transparent focusable ease-in-out inline i-text-$color-button-link-text active:underline hover:underline', // .button--link
+  }
+
+  const buttonSizes = {
+    large: 'py-12 px-16',
+    medium: 'py-10 px-14',
+    custom: 'px-[15px] py-[11px]',
+    small: 'py-8 px-16',
+    xsmall: 'py-6 px-16',
+    pill: 'min-h-[44px] min-w-[44px]',
+    pillSmall: 'min-h-32 min-w-32',
+    linkSmall: 'p-0',
+  }
+
+  const buttonTextSizes = {
+    medium: 'text-m leading-[24]',
+    xsmall: 'text-xs'
+  }
+
   const ccButton = {
     // Buttontypes
     buttonSecondary:
-    'py-10 px-14 text-m leading-[24] ' + buttonVariants.secondaryDefault,
-    buttonSecondarySmall:
-    'py-6 px-16 text-xs ' + buttonVariants.secondaryDefault,
+    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondaryDefault}`,
+    buttonSecondarySmall: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonTypes.secondaryDefault}`,
     buttonSecondaryQuiet:
-    'py-10 px-14 text-m leading-[24] ' + buttonVariants.buttonFlat ,
-    buttonSecondarySmallQuiet:
-    'py-6 px-16 text-xs ' + buttonVariants.buttonFlat,
+    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat}`,
+    buttonSecondarySmallQuiet: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonVariants.buttonFlat}`,
     buttonSecondaryLoading:
-    'py-10 px-14 text-m leading-[24] ' + buttonVariants.secondaryDefault + buttonVariants.buttonInProgress,
-    buttonSecondarySmallLoading:
-    'py-6 px-16 text-xs ' + buttonVariants.secondaryDefault + buttonVariants.buttonInProgress,
-    buttonSecondarySmallQuietLoading:
-    'py-6 px-16 text-xs ' + buttonVariants.buttonFlat + buttonVariants.buttonInProgress,
+    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondaryDefault} ${buttonVariants.buttonInProgress}`,
+    buttonSecondarySmallLoading: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonTypes.secondaryDefault} ${buttonVariants.buttonInProgress}`,
+    buttonSecondarySmallQuietLoading: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonVariants.buttonFlat} ${buttonVariants.buttonInProgress}`,
     buttonSecondaryQuietLoading:
-    'py-10 px-14 text-m leading-[24] ' + buttonVariants.buttonFlat + buttonVariants.buttonInProgress,
-    buttonPrimary:
-      'py-12 px-16 text-m leading-[24] ' + buttonVariants.primaryDefault,
-    buttonPrimaryQuiet:
-      'py-12 px-16 text-m leading-[24] ' + buttonVariants.buttonFlat,
-    buttonPrimarySmall:
-      'py-8 px-16 text-xs ' + buttonVariants.primaryDefault,
-    buttonPrimarySmallQuiet:
-      'py-8 px-16 text-xs ' + buttonVariants.buttonFlat,
-    buttonPrimaryLoading:
-      'py-12 px-16 text-m leading-[24] ' + buttonVariants.primaryDefault + buttonVariants.buttonInProgress,
-    buttonPrimarySmallLoading:
-      'py-8 px-16 text-xs  ' + buttonVariants.primaryDefault + buttonVariants.buttonInProgress,
-    buttonPrimaryQuietLoading:
-      'py-12 px-16 text-m leading-[24]  ' + buttonVariants.buttonFlat + buttonVariants.buttonInProgress,
-    buttonPrimarySmallQuietLoading:
-      'py-8 px-16 text-xs  ' + buttonVariants.buttonFlat + buttonVariants.buttonInProgress,
+    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat} ${buttonVariants.buttonInProgress}`,
+    buttonPrimary: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.primaryDefault}`,
+    buttonPrimaryQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat}`,
+    buttonPrimarySmall: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.primaryDefault}`,
+    buttonPrimarySmallQuiet: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonFlat}`,
+    buttonPrimaryLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.primaryDefault} ${buttonVariants.buttonInProgress}`,
+    buttonPrimarySmallLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.primaryDefault} ${buttonVariants.buttonInProgress}`,
+    buttonPrimaryQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat} ${buttonVariants.buttonInProgress}`,
+    buttonPrimarySmallQuietLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonFlat} ${buttonVariants.buttonInProgress}`,
+    buttonUtility: `${buttonSizes.custom} ${buttonTextSizes.medium} ${buttonTypes.utilityDefault}`,
+    buttonUtilityQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonUtilityFlat}`,
+    buttonUtilitySmall: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.utilityDefault}`,
+    buttonUtilitySmallQuiet: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonUtilityFlat}`,
+    buttonUtilityLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.utilityDefault} ${buttonVariants.buttonInProgress}`,
+    buttonUtilitySmallLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.utilityDefault} ${buttonVariants.buttonInProgress}`,
+    buttonUtilityQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonUtilityFlat} ${buttonVariants.buttonInProgress}`,
+    buttonUtilitySmallQuietLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonUtilityFlat} ${buttonVariants.buttonInProgress}`,
+    buttonDestructive: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.destructiveDefault}`,
+    buttonDestructiveQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonDestructiveFlat}`,
+    buttonDestructiveSmall: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.destructiveDefault}`,
+    buttonDestructiveSmallQuiet: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonDestructiveFlat}`,
+    buttonDestructiveLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.destructiveDefault} ${buttonVariants.buttonInProgress}`,
+    buttonDestructiveSmallLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.destructiveDefault} ${buttonVariants.buttonInProgress}`,
+    buttonDestructiveQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonDestructiveFlat} ${buttonVariants.buttonInProgress}`,
+    buttonDestructiveSmallQuietLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonUtilityFlat} ${buttonVariants.buttonInProgress}`,
+
+    buttonPill: `${buttonSizes.pill} ${buttonTextSizes.medium} ${buttonTypes.buttonPill}`,
+    buttonPillSmall: `${buttonSizes.pillSmall} ${buttonTextSizes.xsmall} ${buttonTypes.buttonPill}`,
+
+    buttonLink: `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.buttonLink}`,
+    buttonLinkSmall: `${buttonSizes.linkSmall} ${buttonTextSizes.xsmall} ${buttonTypes.buttonLink}`,
+    linkAsButton: `${buttonSizes.medium} ${buttonTextSizes.medium} inline-block hover:no-underline`,
+    buttonIsDisabled: buttonVariants.buttonIsDisabled,
     a11y: 'sr-only',
   };
 
@@ -95,6 +133,31 @@ export const Button = forwardRef<
     [ccButton.buttonPrimaryQuiet]: primary && !small && quiet && !loading,
     [ccButton.buttonPrimaryQuietLoading]: primary && !small && quiet && loading,
     [ccButton.buttonPrimaryLoading]: primary && !small && !quiet && loading,
+
+    [ccButton.buttonUtility]: utility && !small && !quiet && !loading,
+    [ccButton.buttonUtilitySmall]: utility && small && !quiet && !loading,
+    [ccButton.buttonUtilitySmallQuiet]: utility && small && quiet && !loading,
+    [ccButton.buttonUtilitySmallLoading]: utility && small && !quiet && loading,
+    [ccButton.buttonUtilitySmallQuietLoading]: utility && small && quiet && loading,
+    [ccButton.buttonUtilityQuiet]: utility && !small && quiet && !loading,
+    [ccButton.buttonUtilityQuietLoading]: utility && !small && quiet && loading,
+    [ccButton.buttonUtilityLoading]: utility && !small && !quiet && loading,
+
+    [ccButton.buttonDestructive]: negative && !small && !quiet && !loading,
+    [ccButton.buttonDestructiveSmall]: negative && small && !quiet && !loading,
+    [ccButton.buttonDestructiveSmallQuiet]: negative && small && quiet && !loading,
+    [ccButton.buttonDestructiveSmallLoading]: negative && small && !quiet && loading,
+    [ccButton.buttonDestructiveSmallQuietLoading]: negative && small && quiet && loading,
+    [ccButton.buttonDestructiveQuiet]: negative && !small && quiet && !loading,
+    [ccButton.buttonDestructiveQuietLoading]: negative && !small && quiet && loading,
+    [ccButton.buttonDestructiveLoading]: negative && !small && !quiet && loading,
+
+    [ccButton.buttonPill]: pill && !small,
+    [ccButton.buttonPillSmall]: pill && small,
+    [ccButton.buttonLink]: link && !small,
+    [ccButton.buttonLinkSmall]: link && small,
+    [ccButton.buttonIsDisabled]: props.disabled,
+    [ccButton.linkAsButton]: !!props.href,
   });
 
   return (

--- a/packages/button/src/component.tsx
+++ b/packages/button/src/component.tsx
@@ -40,7 +40,7 @@ export const Button = forwardRef<
   const buttonTypes = {
     primary: `border-0 rounded-8 ${buttonStyling.default}`,
     secondary: `border-2 rounded-8 ${buttonStyling.default}`,
-    utility: `border rounded-4 ${buttonStyling.default} ${buttonColors.utility}`,
+    utility: `border rounded-4 ${buttonStyling.default}`,
     negative: `border-0 rounded-8 ${buttonStyling.default}`,
     pill:
     `p-4 rounded-full border-0 inline-flex items-center justify-center hover:bg-clip-padding ${buttonStyling.default}`, // .button--pill
@@ -48,11 +48,12 @@ export const Button = forwardRef<
   }
 
   const buttonSizes = {
-    large: 'py-12 px-16',
-    medium: 'py-10 px-14',
-    custom: 'px-[15px] py-[11px]',
-    small: 'py-8 px-16',
     xsmall: 'py-6 px-16',
+    small: 'py-8 px-16',
+    medium: 'py-10 px-14',
+    large: 'py-12 px-16',
+    utility: 'py-[11px] px-[15px]',
+    smallUtility: 'py-[7px] px-[15px]',
     pill: 'min-h-[44px] min-w-[44px]',
     pillSmall: 'min-h-32 min-w-32',
     linkSmall: 'p-0',
@@ -64,7 +65,6 @@ export const Button = forwardRef<
   }
 
   const buttonVariants = {
-    // secondary: `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary}`,
     buttonInProgress:
       'border-transparent animate-inprogress pointer-events-none i-text-$color-button-loading-text i-bg-$color-button-loading-background', // .button--in-progress, a.button--in-progress:visited
     buttonFlat:
@@ -73,16 +73,24 @@ export const Button = forwardRef<
     negativeFlat: `border-0 rounded-8 ${buttonStyling.default}`, // .button--utility.button--quiet, .button--flat
     // Disabled
     buttonIsDisabled:
-      'font-bold max-w-max justify-center transition-colors ease-in-out cursor-default pointer-events-none', // .button:disabled, .button--is-disabled
+      'font-bold max-w-max justify-center transition-colors ease-in-out cursor-default pointer-events-none i-text-$color-button-disabled-text i-bg-$color-button-disabled-background', // .button:disabled, .button--is-disabled
   }
   const ccButton = {
     // Buttontypes
     buttonSecondary:
-    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary} ${buttonColors.secondary}`,
+    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary} ${buttonColors.secondary}`, // .button--secondary, .button--default, .button
+    buttonSecondaryHref:
+    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary} ${buttonColors.secondary}`, // .button--secondary, .button--default, .button
+    buttonSecondaryDisabled:
+    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary} ${buttonVariants.buttonIsDisabled}`,
     buttonSecondarySmall: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonTypes.secondary} ${buttonColors.secondary}`,
+    buttonSecondarySmallDisabled: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonTypes.secondary} ${buttonVariants.buttonIsDisabled}`,
     buttonSecondaryQuiet:
     `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat} ${buttonColors.flat}`,
+    buttonSecondaryQuietDisabled:
+    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat} ${buttonVariants.buttonIsDisabled}`,
     buttonSecondarySmallQuiet: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonVariants.buttonFlat} ${buttonColors.flat}`,
+    buttonSecondarySmallQuietDisabled: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonVariants.buttonFlat} ${buttonVariants.buttonIsDisabled}`,
     buttonSecondaryLoading:
     `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary} ${buttonVariants.buttonInProgress}`,
     buttonSecondarySmallLoading: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonTypes.secondary} ${buttonVariants.buttonInProgress}`,
@@ -91,27 +99,39 @@ export const Button = forwardRef<
     `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat} ${buttonVariants.buttonInProgress}`,
 
     buttonPrimary: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.primary} ${buttonColors.primary}`,
+    buttonPrimaryDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonIsDisabled} ${buttonTypes.primary}`,
     buttonPrimarySmall: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.primary} ${buttonColors.primary}`,
+    buttonPrimarySmallDisabled: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonIsDisabled} ${buttonTypes.primary} `,
     buttonPrimaryQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat} ${buttonColors.flat}`,
+    buttonPrimaryQuietDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat} ${buttonVariants.buttonIsDisabled}`,
     buttonPrimarySmallQuiet: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonFlat} ${buttonColors.flat}`,
+    buttonPrimarySmallQuietDisabled: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonFlat} ${buttonVariants.buttonIsDisabled}`,
     buttonPrimaryLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonInProgress} ${buttonTypes.primary}`,
     buttonPrimarySmallLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonInProgress} ${buttonTypes.primary}`,
     buttonPrimarySmallQuietLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonFlat} ${buttonVariants.buttonInProgress} ${buttonTypes.primary}`,
     buttonPrimaryQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonFlat} ${buttonVariants.buttonInProgress}`,
 
-    buttonUtility: `${buttonSizes.custom} ${buttonTextSizes.medium} ${buttonTypes.utility} ${buttonColors.utility}`,
+    buttonUtility: `${buttonSizes.utility} ${buttonTextSizes.medium} ${buttonTypes.utility} ${buttonColors.utility}`,
+    buttonUtilityDisabled: `${buttonSizes.utility} ${buttonTextSizes.medium} ${buttonTypes.utility} ${buttonVariants.buttonIsDisabled}`,
     buttonUtilityQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonUtilityFlat} ${buttonColors.utilityFlat}`,
-    buttonUtilitySmall: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.utility} ${buttonColors.utility}`,
-    buttonUtilitySmallQuiet: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonUtilityFlat} ${buttonColors.utilityFlat}`,
+    buttonUtilityQuietDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonUtilityFlat} ${buttonVariants.buttonIsDisabled}`,
+    buttonUtilitySmall: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonTypes.utility} ${buttonColors.utility}`,
+    buttonUtilitySmallDisabled: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonTypes.utility} ${buttonVariants.buttonIsDisabled}`,
+    buttonUtilitySmallQuiet: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonVariants.buttonUtilityFlat} ${buttonColors.utilityFlat}`,
+    buttonUtilitySmallQuietDisabled: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonVariants.buttonUtilityFlat} ${buttonVariants.buttonIsDisabled}`,
     buttonUtilityLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.utility} ${buttonVariants.buttonInProgress}`,
-    buttonUtilitySmallLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.utility} ${buttonVariants.buttonInProgress}`,
+    buttonUtilitySmallLoading: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonTypes.utility} ${buttonVariants.buttonInProgress}`,
     buttonUtilityQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.buttonInProgress} ${buttonVariants.buttonUtilityFlat}`,
-    buttonUtilitySmallQuietLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonInProgress} ${buttonVariants.buttonUtilityFlat}`,
+    buttonUtilitySmallQuietLoading: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonVariants.buttonInProgress} ${buttonVariants.buttonUtilityFlat}`,
 
     buttonNegative: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.negative} ${buttonColors.destructive}`,
+    buttonNegativeDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.negative} ${buttonVariants.buttonIsDisabled}`,
     buttonNegativeQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.negativeFlat} ${buttonColors.negativeFlat}`,
+    buttonNegativeQuietDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.negativeFlat}${buttonVariants.buttonIsDisabled}`,
     buttonNegativeSmall: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.negative} ${buttonColors.destructive}`,
+    buttonNegativeSmallDisabled: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.negative} ${buttonVariants.buttonIsDisabled}`,
     buttonNegativeSmallQuiet: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.negativeFlat} ${buttonColors.negativeFlat}`,
+    buttonNegativeSmallQuietDisabled: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.negativeFlat} ${buttonVariants.buttonIsDisabled}`,
     buttonNegativeLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.negative} ${buttonVariants.buttonInProgress}`,
     buttonNegativeSmallLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.buttonInProgress} ${buttonTypes.negative}`,
     buttonNegativeQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.negativeFlat} ${buttonTypes.negative} ${buttonVariants.buttonInProgress}`,
@@ -124,7 +144,7 @@ export const Button = forwardRef<
 
     link: `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.link}`,
     linkSmall: `${buttonSizes.linkSmall} ${buttonTextSizes.xsmall} ${buttonTypes.link}`,
-    linkAsButton: `${buttonSizes.medium} ${buttonTextSizes.medium} inline-block hover:no-underline`,
+    linkAsButton: 'inline-block hover:no-underline',
     buttonIsDisabled: buttonVariants.buttonIsDisabled,
     a11y: 'sr-only',
   };
@@ -132,40 +152,55 @@ export const Button = forwardRef<
   const buttonType = Object.keys(buttonTypes).find(b => !!props[b]);
   
   const classes = classNames(props.className, {
-    // [!loading && !props.disabled && buttonType ? buttonColors[buttonType] : (loading ? buttonColors.loading : buttonColors.disabled)]: true,
-    [ccButton.buttonSecondary]: (secondary || !buttonType) && !small && !quiet && !loading,
-    [ccButton.buttonSecondarySmall]: secondary && small && !quiet && !loading,
+    [ccButton.buttonSecondary]: (secondary || !buttonType) && !small && !quiet && !loading && !props.disabled,
+    [ccButton.buttonSecondaryDisabled]: (secondary || !buttonType) && !small && !quiet && !loading && props.disabled,
+    [ccButton.buttonSecondarySmall]: secondary && small && !quiet && !loading && !props.disabled,
+    [ccButton.buttonSecondarySmallDisabled]: secondary && small && !quiet && !loading && props.disabled,
     [ccButton.buttonSecondarySmallLoading]: secondary && small && !quiet && loading,
-    [ccButton.buttonSecondarySmallQuiet]: secondary && small && quiet && !loading,
+    [ccButton.buttonSecondarySmallQuiet]: secondary && small && quiet && !loading && !props.disabled,
+    [ccButton.buttonSecondarySmallQuietDisabled]: secondary && small && quiet && !loading && props.disabled,
     [ccButton.buttonSecondarySmallQuietLoading]: secondary && small && quiet && loading,
-    [ccButton.buttonSecondaryQuiet]: secondary && !small && quiet && !loading,
+    [ccButton.buttonSecondaryQuiet]: secondary && !small && quiet && !loading && !props.disabled,
+    [ccButton.buttonSecondaryQuietDisabled]: secondary && !small && quiet && !loading && props.disabled,
     [ccButton.buttonSecondaryQuietLoading]: secondary && !small && quiet && loading,
     [ccButton.buttonSecondaryLoading]: secondary && !small && !quiet && loading,
     
-    [ccButton.buttonPrimary]: primary && !small && !quiet && !loading,
-    [ccButton.buttonPrimarySmall]: primary && small && !quiet && !loading,
-    [ccButton.buttonPrimarySmallQuiet]: primary && small && quiet && !loading,
+    [ccButton.buttonPrimary]: primary && !small && !quiet && !loading && !props.disabled,
+    [ccButton.buttonPrimaryDisabled]: primary && !small && !quiet && !loading && props.disabled,
+    [ccButton.buttonPrimarySmall]: primary && small && !quiet && !loading && !props.disabled,
+    [ccButton.buttonPrimarySmallDisabled]: primary && small && !quiet && !loading && props.disabled,
+    [ccButton.buttonPrimarySmallQuiet]: primary && small && quiet && !loading && !props.disabled,
+    [ccButton.buttonPrimarySmallQuietDisabled]: primary && small && quiet && !loading && props.disabled,
     [ccButton.buttonPrimarySmallLoading]: primary && small && !quiet && loading,
     [ccButton.buttonPrimarySmallQuietLoading]: primary && small && quiet && loading,
-    [ccButton.buttonPrimaryQuiet]: primary && !small && quiet && !loading,
+    [ccButton.buttonPrimaryQuiet]: primary && !small && quiet && !loading && !props.disabled,
+    [ccButton.buttonPrimaryQuietDisabled]: primary && !small && quiet && !loading && props.disabled,
     [ccButton.buttonPrimaryQuietLoading]: primary && !small && quiet && loading,
     [ccButton.buttonPrimaryLoading]: primary && !small && !quiet && loading,
 
-    [ccButton.buttonUtility]: utility && !small && !quiet && !loading,
-    [ccButton.buttonUtilitySmall]: utility && small && !quiet && !loading,
-    [ccButton.buttonUtilitySmallQuiet]: utility && small && quiet && !loading,
+    [ccButton.buttonUtility]: utility && !small && !quiet && !loading && !props.disabled,
+    [ccButton.buttonUtilityDisabled]: utility && !small && !quiet && !loading && props.disabled,
+    [ccButton.buttonUtilitySmall]: utility && small && !quiet && !loading && !props.disabled,
+    [ccButton.buttonUtilitySmallDisabled]: utility && small && !quiet && !loading && props.disabled,
+    [ccButton.buttonUtilitySmallQuiet]: utility && small && quiet && !loading && !props.disabled,
+    [ccButton.buttonUtilitySmallQuietDisabled]: utility && small && quiet && !loading && props.disabled,
     [ccButton.buttonUtilitySmallLoading]: utility && small && !quiet && loading,
     [ccButton.buttonUtilitySmallQuietLoading]: utility && small && quiet && loading,
-    [ccButton.buttonUtilityQuiet]: utility && !small && quiet && !loading,
+    [ccButton.buttonUtilityQuiet]: utility && !small && quiet && !loading && !props.disabled,
+    [ccButton.buttonUtilityQuietDisabled]: utility && !small && quiet && !loading && props.disabled,
     [ccButton.buttonUtilityQuietLoading]: utility && !small && quiet && loading,
     [ccButton.buttonUtilityLoading]: utility && !small && !quiet && loading,
 
-    [ccButton.buttonNegative]: negative && !small && !quiet && !loading,
-    [ccButton.buttonNegativeSmall]: negative && small && !quiet && !loading,
-    [ccButton.buttonNegativeSmallQuiet]: negative && small && quiet && !loading,
+    [ccButton.buttonNegative]: negative && !small && !quiet && !loading && !props.disabled,
+    [ccButton.buttonNegativeDisabled]: negative && !small && !quiet && !loading && props.disabled,
+    [ccButton.buttonNegativeSmall]: negative && small && !quiet && !loading && !props.disabled,
+    [ccButton.buttonNegativeSmallDisabled]: negative && small && !quiet && !loading && props.disabled,
+    [ccButton.buttonNegativeSmallQuiet]: negative && small && quiet && !loading && !props.disabled,
+    [ccButton.buttonNegativeSmallQuietDisabled]: negative && small && quiet && !loading && props.disabled,
     [ccButton.buttonNegativeSmallLoading]: negative && small && !quiet && loading,
     [ccButton.buttonNegativeSmallQuietLoading]: negative && small && quiet && loading,
-    [ccButton.buttonNegativeQuiet]: negative && !small && quiet && !loading,
+    [ccButton.buttonNegativeQuiet]: negative && !small && quiet && !loading && !props.disabled,
+    [ccButton.buttonNegativeQuietDisabled]: negative && !small && quiet && !loading && props.disabled,
     [ccButton.buttonNegativeQuietLoading]: negative && !small && quiet && loading,
     [ccButton.buttonNegativeLoading]: negative && !small && !quiet && loading,
 
@@ -175,7 +210,6 @@ export const Button = forwardRef<
     [ccButton.pillSmallLoading]: pill && small && loading,
     [ccButton.link]: link && !small,
     [ccButton.linkSmall]: link && small,
-    // [ccButton.buttonIsDisabled]: props.disabled,
     [ccButton.linkAsButton]: !!props.href,
   });
 

--- a/packages/button/src/component.tsx
+++ b/packages/button/src/component.tsx
@@ -8,6 +8,15 @@ import { messages as nbMessages} from './locales/nb/messages.mjs';
 import { messages as fiMessages} from './locales/fi/messages.mjs';
 import { activateI18n } from '../../i18n';
 
+const buttonTypes = [    
+  'primary',
+  'secondary',
+  'negative',
+  'utility',
+  'pill',
+  'link',
+] as const;
+
 export const Button = forwardRef<
   HTMLButtonElement | HTMLAnchorElement,
   ButtonProps
@@ -25,135 +34,7 @@ export const Button = forwardRef<
     ...rest
   } = props;
 
-  const buttonDefaultStyling = 'font-bold max-w-max focusable justify-center transition-colors ease-in-out';
-
-  const buttonColors = {
-    primary: 'i-text-$color-button-primary-text hover:i-text-$color-button-primary-text i-bg-$color-button-primary-background hover:i-bg-$color-button-primary-background-hover active:i-bg-$color-button-primary-background-active',
-    secondary: 'i-text-$color-button-secondary-text hover:i-text-$color-button-secondary-text i-border-$color-button-secondary-border i-bg-$color-button-secondary-background hover:i-bg-$color-button-secondary-background-hover hover:i-border-$color-button-secondary-border-hover active:i-bg-$color-button-secondary-background-active',
-    utility: 'i-text-$color-button-utility-text hover:i-text-$color-button-utility-text i-bg-$color-button-utility-background i-border-$color-button-utility-border hover:i-bg-$color-button-utility-background hover:i-border-$color-button-utility-border-hover active:i-border-$color-button-utility-border-active',
-    destructive: 'i-bg-$color-button-negative-background i-text-$color-button-negative-text hover:i-text-$color-button-negative-text hover:i-bg-$color-button-negative-background-hover active:i-bg-$color-button-negative-background-active',
-    pill: 'i-text-$color-button-pill-icon hover:i-text-$color-button-pill-icon-hover active:i-text-$color-button-pill-icon-active i-bg-$color-button-pill-background hover:i-bg-$color-button-pill-background-hover active:i-bg-$color-button-pill-background-active',
-    disabled: 'i-text-$color-button-disabled-text i-bg-$color-button-disabled-background',
-    quiet: 'i-bg-$color-button-quiet-background i-text-$color-button-quiet-text hover:i-bg-$color-button-quiet-background-hover active:i-bg-$color-button-quiet-background-active',
-    utilityQuiet: 'i-text-$color-button-utility-quiet-text i-bg-$color-button-utility-quiet-background hover:i-bg-$color-button-utility-quiet-background-hover',
-    negativeQuiet: 'i-bg-$color-button-negative-quiet-background i-text-$color-button-negative-quiet-text hover:i-bg-$color-button-negative-quiet-background-hover active:i-bg-$color-button-negative-quiet-background-active',
-    loading: 'i-text-$color-button-loading-text i-bg-$color-button-loading-background',
-    link: 'i-text-$color-button-link-text',
-  };
-
-  const buttonTypes = {
-    primary: `border-0 rounded-8 ${buttonDefaultStyling}`,
-    secondary: `border-2 rounded-8 ${buttonDefaultStyling}`,
-    utility: `border rounded-4 ${buttonDefaultStyling}`,
-    negative: `border-0 rounded-8 ${buttonDefaultStyling}`,
-    pill:
-    `p-4 rounded-full border-0 inline-flex items-center justify-center hover:bg-clip-padding ${buttonDefaultStyling}`, // .button--pill
-    link: `max-w-max bg-transparent focusable ease-in-out inline active:underline hover:underline ${buttonColors.link}`, // .button--link
-  }
-
-  const buttonSizes = {
-    xsmall: 'py-6 px-16',
-    small: 'py-8 px-16',
-    medium: 'py-10 px-14',
-    large: 'py-12 px-16',
-    utility: 'py-[11px] px-[15px]',
-    smallUtility: 'py-[7px] px-[15px]',
-    pill: 'min-h-[44px] min-w-[44px]',
-    pillSmall: 'min-h-32 min-w-32',
-    linkSmall: 'p-0',
-  }
-
-  const buttonTextSizes = {
-    medium: 'text-m leading-[24]',
-    xsmall: 'text-xs'
-  }
-
-  const buttonVariants = {
-    inProgress:
-      `border-transparent animate-inprogress pointer-events-none ${buttonColors.loading}`, // .button--in-progress, a.button--in-progress:visited
-    quiet:
-      `border-0 rounded-8 ${buttonDefaultStyling}`, // .button--quiet, .button--flat
-    utilityQuiet: `bg-transparent border-0 rounded-4 ${buttonDefaultStyling}`, // .button--utility.button--quiet, .button--flat
-    negativeQuiet: `border-0 rounded-8 ${buttonDefaultStyling}`, // .button--utility.button--quiet, .button--flat
-    // Disabled
-    isDisabled:
-      `font-bold max-w-max justify-center transition-colors ease-in-out cursor-default pointer-events-none ${buttonColors.disabled}`, // .button:disabled, .button--is-disabled
-  }
-
-  const ccButton = {
-    // Buttontypes
-    secondary:
-    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary} ${buttonColors.secondary}`, // .button--secondary, .button--default, .button
-    secondaryHref:
-    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary} ${buttonColors.secondary}`, // .button--secondary, .button--default, .button
-    secondaryDisabled:
-    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary} ${buttonVariants.isDisabled}`,
-    secondarySmall: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonTypes.secondary} ${buttonColors.secondary}`,
-    secondarySmallDisabled: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonTypes.secondary} ${buttonVariants.isDisabled}`,
-    secondaryQuiet:
-    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonVariants.quiet} ${buttonColors.quiet}`,
-    secondaryQuietDisabled:
-    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonVariants.quiet} ${buttonVariants.isDisabled}`,
-    secondarySmallQuiet: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonVariants.quiet} ${buttonColors.quiet}`,
-    secondarySmallQuietDisabled: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonVariants.quiet} ${buttonVariants.isDisabled}`,
-    secondaryLoading:
-    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.secondary} ${buttonVariants.inProgress}`,
-    secondarySmallLoading: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall}  ${buttonTypes.secondary} ${buttonVariants.inProgress}`,
-    secondarySmallQuietLoading: `${buttonTextSizes.xsmall} ${buttonSizes.xsmall} ${buttonVariants.quiet} ${buttonVariants.inProgress}`,
-    secondaryQuietLoading:
-    `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonVariants.quiet} ${buttonVariants.inProgress}`,
-
-    primary: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.primary} ${buttonColors.primary}`,
-    primaryDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.isDisabled} ${buttonTypes.primary}`,
-    primarySmall: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.primary} ${buttonColors.primary}`,
-    primarySmallDisabled: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.isDisabled} ${buttonTypes.primary} `,
-    primaryQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.quiet} ${buttonColors.quiet}`,
-    primaryQuietDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.quiet} ${buttonVariants.isDisabled}`,
-    primarySmallQuiet: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.quiet} ${buttonColors.quiet}`,
-    primarySmallQuietDisabled: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.quiet} ${buttonVariants.isDisabled}`,
-    primaryLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.inProgress} ${buttonTypes.primary}`,
-    primarySmallLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.inProgress} ${buttonTypes.primary} `,
-    primarySmallQuietLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.quiet} ${buttonVariants.inProgress} ${buttonTypes.primary}`,
-    primaryQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.quiet} ${buttonVariants.inProgress}`,
-
-    utility: `${buttonSizes.utility} ${buttonTextSizes.medium} ${buttonTypes.utility} ${buttonColors.utility}`,
-    utilityDisabled: `${buttonSizes.utility} ${buttonTextSizes.medium} ${buttonTypes.utility} ${buttonVariants.isDisabled}`,
-    utilityQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.utilityQuiet} ${buttonColors.utilityQuiet}`,
-    utilityQuietDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.utilityQuiet} ${buttonVariants.isDisabled}`,
-    utilitySmall: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonTypes.utility} ${buttonColors.utility}`,
-    utilitySmallDisabled: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonTypes.utility} ${buttonVariants.isDisabled}`,
-    utilitySmallQuiet: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonVariants.utilityQuiet} ${buttonColors.utilityQuiet}`,
-    utilitySmallQuietDisabled: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonVariants.utilityQuiet} ${buttonVariants.isDisabled}`,
-    utilityLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.utility} ${buttonVariants.inProgress}`,
-    utilitySmallLoading: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonTypes.utility} ${buttonVariants.inProgress}`,
-    utilityQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.inProgress} ${buttonVariants.utilityQuiet}`,
-    utilitySmallQuietLoading: `${buttonSizes.smallUtility} ${buttonTextSizes.xsmall} ${buttonVariants.inProgress} ${buttonVariants.utilityQuiet}`,
-
-    negative: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.negative} ${buttonColors.destructive}`,
-    negativeDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.negative} ${buttonVariants.isDisabled}`,
-    negativeQuiet: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.negativeQuiet} ${buttonColors.negativeQuiet}`,
-    negativeQuietDisabled: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.negativeQuiet}${buttonVariants.isDisabled}`,
-    negativeSmall: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.negative} ${buttonColors.destructive}`,
-    negativeSmallDisabled: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonTypes.negative} ${buttonVariants.isDisabled}`,
-    negativeSmallQuiet: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.negativeQuiet} ${buttonColors.negativeQuiet}`,
-    negativeSmallQuietDisabled: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.negativeQuiet} ${buttonVariants.isDisabled}`,
-    negativeLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonTypes.negative} ${buttonVariants.inProgress}`,
-    negativeSmallLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.inProgress} ${buttonTypes.negative}`,
-    negativeQuietLoading: `${buttonSizes.large} ${buttonTextSizes.medium} ${buttonVariants.negativeQuiet} ${buttonTypes.negative} ${buttonVariants.inProgress}`,
-    negativeSmallQuietLoading: `${buttonSizes.small} ${buttonTextSizes.xsmall} ${buttonVariants.negativeQuiet} ${buttonVariants.inProgress}`,
-
-    pill: `${buttonSizes.pill} ${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonColors.pill}`,
-    pillSmall: `${buttonSizes.pillSmall} ${buttonTextSizes.xsmall} ${buttonTypes.pill} ${buttonColors.pill}`,
-    pillLoading: `${buttonSizes.pill} ${buttonTextSizes.medium} ${buttonTypes.pill} ${buttonVariants.inProgress}`,
-    pillSmallLoading: `${buttonSizes.pillSmall} ${buttonTextSizes.xsmall} ${buttonTypes.pill} ${buttonVariants.inProgress}`,
-
-    link: `${buttonSizes.medium} ${buttonTextSizes.medium} ${buttonTypes.link}`,
-    linkSmall: `${buttonSizes.linkSmall} ${buttonTextSizes.xsmall} ${buttonTypes.link}`,
-    linkAsButton: 'inline-block hover:no-underline',
-    a11y: 'sr-only',
-  };
-
-  const buttonType = Object.keys(buttonTypes).find(b => !!props[b]);
+  const buttonType = buttonTypes.find(b => !!props[b]);
   
   const classes = classNames(props.className, {
     [ccButton.secondary]: (secondary || !buttonType) && !small && !quiet && !loading && !props.disabled,

--- a/packages/button/src/component.tsx
+++ b/packages/button/src/component.tsx
@@ -28,79 +28,73 @@ export const Button = forwardRef<
     ...rest
   } = props;
 
-   const ccButton = {
-    // Buttontypes
-    buttonSecondary:
-      'border-2  rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-text-$color-button-secondary-text hover:i-text-$color-button-secondary-text i-border-$color-button-secondary-border i-bg-$color-button-secondary-background hover:i-bg-$color-button-secondary-background-hover hover:i-border-$color-button-secondary-border-hover active:i-bg-$color-button-secondary-background-active', // .button, .button--secondary, .button--default. using tailwind ease-in-out instead of fabric transition-timing-function: cubic-bezier(0.46, 0.03, 0.52, 0.96)
-    buttonPrimary:
-      'border-0  rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-text-$color-button-primary-text hover:i-text-$color-button-primary-text i-bg-$color-button-primary-background hover:i-bg-$color-button-primary-background-hover! active:i-bg-$color-button-primary-background-active', // .button--primary, .button--cta
+  const buttonVariants = {
+    buttonInProgress:
+      'border-transparent! animate-inprogress i-text-$color-button-loading-text! pointer-events-none i-bg-$color-button-loading-background!', // .button--in-progress, a.button--in-progress:visited
     buttonFlat:
       'border-0!  rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-bg-$color-button-quiet-background! i-text-$color-button-quiet-text! hover:i-bg-$color-button-quiet-background-hover! active:i-bg-$color-button-quiet-background-active!', // .button--quiet, .button--flat
-    buttonDestructive:
-      'border-0  rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-bg-$color-button-negative-background i-text-$color-button-negative-text hover:i-text-$color-button-negative-text hover:i-bg-$color-button-negative-background-hover active:i-bg-$color-button-negative-background-active', // .button--destructive
-    buttonDestructiveFlat:
-      'border-0  rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-bg-$color-button-negative-quiet-background! i-text-$color-button-negative-quiet-text! hover:i-bg-$color-button-negative-quiet-background-hover! active:i-bg-$color-button-negative-quiet-background-active!', // .button--destructive-flat
-    buttonUtility:
-      'font-bold max-w-max focusable justify-center transition-colors ease-in-out border rounded-4 i-text-$color-button-utility-text hover:i-text-$color-button-utility-text i-bg-$color-button-utility-background i-border-$color-button-utility-border hover:i-bg-$color-button-utility-background hover:i-border-$color-button-utility-border-hover! active:i-border-$color-button-utility-border-active!', // .button--utility
-    buttonUtilityFlat:
-      'bg-transparent border-0 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-text-$color-button-utility-quiet-text i-bg-$color-button-utility-quiet-background hover:i-bg-$color-button-utility-quiet-background-hover rounded-4', // .button--utility-flat
-    buttonPill:
-      'font-bold max-w-max focusable justify-center transition-colors ease-in-out rounded-full! border-0! p-4 i-text-$color-button-pill-icon hover:i-text-$color-button-pill-icon-hover active:i-text-$color-button-pill-icon-active i-bg-$color-button-pill-background hover:i-bg-$color-button-pill-background-hover active:i-bg-$color-button-pill-background-active inline-flex items-center justify-center hover:bg-clip-padding', // .button--pill
-    buttonLink:
-      'max-w-max bg-transparent focusable ease-in-out inline i-text-$color-button-link-text active:underline hover:underline', //.button--link /* Buttons pretending to be links, (Should rather inherit the actual link setup in the future?)  */
-    // Font stuff
-    buttonMediumFontSize: 'leading-[24] text-m', // .button--secondary
-    buttonSecondaryPadding: 'py-10 px-14', // .button--secondary.button--small
-    buttonMediumPadding: 'py-12 px-16', // .button--primary, .button--quiet, .button--destructive, .button--destructive-flat, .button--utility-flat
-    buttonUtilitySizing: 'px-[15px] py-[11px] font-bold', // .button--utility
-    buttonPillSizing: 'min-h-[44px] min-w-[44px]', // .button--utility
-    buttonSmallSecondary: 'px-16 py-6 text-xs', // .button--small
-    buttonSmallPrimary: 'px-16 py-8 text-xs', // .button--small.button--primary, .button--small.button--destructive, .button--small.button--destructive-flat, .button--small.button--order, .button--small.button--quiet
-    buttonSmallUtility: 'px-[15px] py-[7px] text-xs', // .button--small.button--utility
-    buttonSmallButtonPill: 'min-h-32 min-w-32 text-xs', // .button--small.button--pill
-    buttonSmallButtonLink: 'p-0 text-xs', // .button--small.button--link
     // Disabled
     buttonIsDisabled:
       'font-bold max-w-max justify-center transition-colors ease-in-out i-bg-$color-button-disabled-background! i-text-$color-button-disabled-text cursor-default pointer-events-none', // .button:disabled, .button--is-disabled
-    // Progress indicator
-    buttonInProgress:
-      'border-transparent! animate-inprogress i-text-$color-button-loading-text! pointer-events-none i-bg-$color-button-loading-background!', // .button--in-progress, a.button--in-progress:visited
-    linkAsButton: 'inline-block hover:no-underline',
+    primaryDefault: 'border-0 rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-text-$color-button-primary-text hover:i-text-$color-button-primary-text i-bg-$color-button-primary-background hover:i-bg-$color-button-primary-background-hover! active:i-bg-$color-button-primary-background-active',
+    secondaryDefault: 'border-2 font-bold rounded-8 max-w-max focusable justify-center transition-colors ease-in-out i-text-$color-button-secondary-text hover:i-text-$color-button-secondary-text i-border-$color-button-secondary-border i-bg-$color-button-secondary-background hover:i-bg-$color-button-secondary-background-hover hover:i-border-$color-button-secondary-border-hover active:i-bg-$color-button-secondary-background-active'
+  }
+    
+  const ccButton = {
+    // Buttontypes
+    buttonSecondary:
+    'py-10 px-14 text-m leading-[24] ' + buttonVariants.secondaryDefault,
+    buttonSecondarySmall:
+    'py-6 px-16 text-xs ' + buttonVariants.secondaryDefault,
+    buttonSecondaryQuiet:
+    'py-10 px-14 text-m leading-[24] ' + buttonVariants.buttonFlat ,
+    buttonSecondarySmallQuiet:
+    'py-6 px-16 text-xs ' + buttonVariants.buttonFlat,
+    buttonSecondaryLoading:
+    'py-10 px-14 text-m leading-[24] ' + buttonVariants.secondaryDefault + buttonVariants.buttonInProgress,
+    buttonSecondarySmallLoading:
+    'py-6 px-16 text-xs ' + buttonVariants.secondaryDefault + buttonVariants.buttonInProgress,
+    buttonSecondarySmallQuietLoading:
+    'py-6 px-16 text-xs ' + buttonVariants.buttonFlat + buttonVariants.buttonInProgress,
+    buttonSecondaryQuietLoading:
+    'py-10 px-14 text-m leading-[24] ' + buttonVariants.buttonFlat + buttonVariants.buttonInProgress,
+    buttonPrimary:
+      'py-12 px-16 text-m leading-[24] ' + buttonVariants.primaryDefault,
+    buttonPrimaryQuiet:
+      'py-12 px-16 text-m leading-[24] ' + buttonVariants.buttonFlat,
+    buttonPrimarySmall:
+      'py-8 px-16 text-xs ' + buttonVariants.primaryDefault,
+    buttonPrimarySmallQuiet:
+      'py-8 px-16 text-xs ' + buttonVariants.buttonFlat,
+    buttonPrimaryLoading:
+      'py-12 px-16 text-m leading-[24] ' + buttonVariants.primaryDefault + buttonVariants.buttonInProgress,
+    buttonPrimarySmallLoading:
+      'py-8 px-16 text-xs  ' + buttonVariants.primaryDefault + buttonVariants.buttonInProgress,
+    buttonPrimaryQuietLoading:
+      'py-12 px-16 text-m leading-[24]  ' + buttonVariants.buttonFlat + buttonVariants.buttonInProgress,
+    buttonPrimarySmallQuietLoading:
+      'py-8 px-16 text-xs  ' + buttonVariants.buttonFlat + buttonVariants.buttonInProgress,
     a11y: 'sr-only',
   };
 
-  const buttonSecondaryDefault = secondary && !quiet || !buttonTypes.find(b => !!props[b]);
-  const buttonDestructive = negative && !quiet;
-  const buttonFlat = secondary && quiet;
-  const buttonDestructiveFlat = negative && quiet;
-  const buttonUtilityFlat = utility && quiet;
-
   const classes = classNames(props.className, {
-    [ccButton.buttonSecondary]: buttonSecondaryDefault,
-    [`${ccButton.buttonSecondaryPadding} ${ccButton.buttonMediumFontSize}`]: (buttonSecondaryDefault || buttonFlat) && !small,
-    // primary buttons
-    [ccButton.buttonPrimary]: primary,
-    [ccButton.buttonDestructive]: buttonDestructive,
-    [`${ccButton.buttonMediumPadding} ${ccButton.buttonMediumFontSize}`]: (primary || buttonDestructive || buttonDestructiveFlat) && !small,
-    // quiet
-    [`${ccButton.buttonSecondary} ${ccButton.buttonFlat}`]: buttonFlat,
-    [ccButton.buttonDestructiveFlat]: buttonDestructiveFlat,
-    [ccButton.buttonUtilityFlat]: buttonUtilityFlat,
-    // others
-    [ccButton.buttonUtility]: utility,
-    [`${ccButton.buttonUtilitySizing} ${ccButton.buttonMediumFontSize}`]: utility && !small,
-    [ccButton.buttonLink]: link,
-    [ccButton.buttonPill]: pill,
-    [`${ccButton.buttonPillSizing} ${ccButton.buttonMediumFontSize}`]: pill && !small,
-    [ccButton.buttonInProgress]: loading,
-    [ccButton.buttonIsDisabled]: props.disabled,
-    [ccButton.linkAsButton]: !!props.href,
-    // small sizing, all buttons
-    [ccButton.buttonSmallSecondary]: (buttonSecondaryDefault || secondary || buttonFlat) && small,
-    [ccButton.buttonSmallPrimary]: (primary || buttonDestructive || buttonDestructiveFlat ) && small,
-    [ccButton.buttonSmallUtility]: utility && small,
-    [ccButton.buttonSmallButtonPill]: pill && small,
-    [ccButton.buttonSmallButtonLink]: link && small,
+    [ccButton.buttonSecondary]: secondary && !small && !quiet && !loading,
+    [ccButton.buttonSecondarySmall]: secondary && small && !quiet && !loading,
+    [ccButton.buttonSecondarySmallLoading]: secondary && small && !quiet && loading,
+    [ccButton.buttonSecondarySmallQuiet]: secondary && small && quiet && !loading,
+    [ccButton.buttonSecondarySmallQuietLoading]: secondary && small && quiet && loading,
+    [ccButton.buttonSecondaryQuiet]: secondary && !small && quiet && !loading,
+    [ccButton.buttonSecondaryQuietLoading]: secondary && !small && quiet && loading,
+    [ccButton.buttonSecondaryLoading]: secondary && !small && !quiet && loading,
+
+    [ccButton.buttonPrimary]: primary && !small && !quiet && !loading,
+    [ccButton.buttonPrimarySmall]: primary && small && !quiet && !loading,
+    [ccButton.buttonPrimarySmallQuiet]: primary && small && quiet && !loading,
+    [ccButton.buttonPrimarySmallLoading]: primary && small && !quiet && loading,
+    [ccButton.buttonPrimarySmallQuietLoading]: primary && small && quiet && loading,
+    [ccButton.buttonPrimaryQuiet]: primary && !small && quiet && !loading,
+    [ccButton.buttonPrimaryQuietLoading]: primary && !small && quiet && loading,
+    [ccButton.buttonPrimaryLoading]: primary && !small && !quiet && loading,
   });
 
   return (

--- a/packages/button/src/component.tsx
+++ b/packages/button/src/component.tsx
@@ -28,25 +28,79 @@ export const Button = forwardRef<
     ...rest
   } = props;
 
+   const ccButton = {
+    // Buttontypes
+    buttonSecondary:
+      'border-2  rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-text-$color-button-secondary-text hover:i-text-$color-button-secondary-text i-border-$color-button-secondary-border i-bg-$color-button-secondary-background hover:i-bg-$color-button-secondary-background-hover hover:i-border-$color-button-secondary-border-hover active:i-bg-$color-button-secondary-background-active', // .button, .button--secondary, .button--default. using tailwind ease-in-out instead of fabric transition-timing-function: cubic-bezier(0.46, 0.03, 0.52, 0.96)
+    buttonPrimary:
+      'border-0  rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-text-$color-button-primary-text hover:i-text-$color-button-primary-text i-bg-$color-button-primary-background hover:i-bg-$color-button-primary-background-hover! active:i-bg-$color-button-primary-background-active', // .button--primary, .button--cta
+    buttonFlat:
+      'border-0!  rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-bg-$color-button-quiet-background! i-text-$color-button-quiet-text! hover:i-bg-$color-button-quiet-background-hover! active:i-bg-$color-button-quiet-background-active!', // .button--quiet, .button--flat
+    buttonDestructive:
+      'border-0  rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-bg-$color-button-negative-background i-text-$color-button-negative-text hover:i-text-$color-button-negative-text hover:i-bg-$color-button-negative-background-hover active:i-bg-$color-button-negative-background-active', // .button--destructive
+    buttonDestructiveFlat:
+      'border-0  rounded-8 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-bg-$color-button-negative-quiet-background! i-text-$color-button-negative-quiet-text! hover:i-bg-$color-button-negative-quiet-background-hover! active:i-bg-$color-button-negative-quiet-background-active!', // .button--destructive-flat
+    buttonUtility:
+      'font-bold max-w-max focusable justify-center transition-colors ease-in-out border rounded-4 i-text-$color-button-utility-text hover:i-text-$color-button-utility-text i-bg-$color-button-utility-background i-border-$color-button-utility-border hover:i-bg-$color-button-utility-background hover:i-border-$color-button-utility-border-hover! active:i-border-$color-button-utility-border-active!', // .button--utility
+    buttonUtilityFlat:
+      'bg-transparent border-0 font-bold max-w-max focusable justify-center transition-colors ease-in-out i-text-$color-button-utility-quiet-text i-bg-$color-button-utility-quiet-background hover:i-bg-$color-button-utility-quiet-background-hover rounded-4', // .button--utility-flat
+    buttonPill:
+      'font-bold max-w-max focusable justify-center transition-colors ease-in-out rounded-full! border-0! p-4 i-text-$color-button-pill-icon hover:i-text-$color-button-pill-icon-hover active:i-text-$color-button-pill-icon-active i-bg-$color-button-pill-background hover:i-bg-$color-button-pill-background-hover active:i-bg-$color-button-pill-background-active inline-flex items-center justify-center hover:bg-clip-padding', // .button--pill
+    buttonLink:
+      'max-w-max bg-transparent focusable ease-in-out inline i-text-$color-button-link-text active:underline hover:underline', //.button--link /* Buttons pretending to be links, (Should rather inherit the actual link setup in the future?)  */
+    // Font stuff
+    buttonMediumFontSize: 'leading-[24] text-m', // .button--secondary
+    buttonSecondaryPadding: 'py-10 px-14', // .button--secondary.button--small
+    buttonMediumPadding: 'py-12 px-16', // .button--primary, .button--quiet, .button--destructive, .button--destructive-flat, .button--utility-flat
+    buttonUtilitySizing: 'px-[15px] py-[11px] font-bold', // .button--utility
+    buttonPillSizing: 'min-h-[44px] min-w-[44px]', // .button--utility
+    buttonSmallSecondary: 'px-16 py-6 text-xs', // .button--small
+    buttonSmallPrimary: 'px-16 py-8 text-xs', // .button--small.button--primary, .button--small.button--destructive, .button--small.button--destructive-flat, .button--small.button--order, .button--small.button--quiet
+    buttonSmallUtility: 'px-[15px] py-[7px] text-xs', // .button--small.button--utility
+    buttonSmallButtonPill: 'min-h-32 min-w-32 text-xs', // .button--small.button--pill
+    buttonSmallButtonLink: 'p-0 text-xs', // .button--small.button--link
+    // Disabled
+    buttonIsDisabled:
+      'font-bold max-w-max justify-center transition-colors ease-in-out i-bg-$color-button-disabled-background! i-text-$color-button-disabled-text cursor-default pointer-events-none', // .button:disabled, .button--is-disabled
+    // Progress indicator
+    buttonInProgress:
+      'border-transparent! animate-inprogress i-text-$color-button-loading-text! pointer-events-none i-bg-$color-button-loading-background!', // .button--in-progress, a.button--in-progress:visited
+    linkAsButton: 'inline-block hover:no-underline',
+    a11y: 'sr-only',
+  };
+
+  const buttonSecondaryDefault = secondary && !quiet || !buttonTypes.find(b => !!props[b]);
+  const buttonDestructive = negative && !quiet;
+  const buttonFlat = secondary && quiet;
+  const buttonDestructiveFlat = negative && quiet;
+  const buttonUtilityFlat = utility && quiet;
+
   const classes = classNames(props.className, {
-    [ccButton.buttonSecondary]: secondary && !quiet || !buttonTypes.find(b => !!props[b]),
+    [ccButton.buttonSecondary]: buttonSecondaryDefault,
+    [`${ccButton.buttonSecondaryPadding} ${ccButton.buttonMediumFontSize}`]: (buttonSecondaryDefault || buttonFlat) && !small,
     // primary buttons
     [ccButton.buttonPrimary]: primary,
-    [ccButton.buttonDestructive]: negative && !quiet,
+    [ccButton.buttonDestructive]: buttonDestructive,
+    [`${ccButton.buttonMediumPadding} ${ccButton.buttonMediumFontSize}`]: (primary || buttonDestructive || buttonDestructiveFlat) && !small,
     // quiet
-    [ccButton.buttonFlat]: secondary && quiet,
-    [ccButton.buttonDestructiveFlat]: negative && quiet,
-    [ccButton.buttonUtilityFlat]: utility && quiet,
+    [`${ccButton.buttonSecondary} ${ccButton.buttonFlat}`]: buttonFlat,
+    [ccButton.buttonDestructiveFlat]: buttonDestructiveFlat,
+    [ccButton.buttonUtilityFlat]: buttonUtilityFlat,
     // others
-    [ccButton.buttonSmall]: small,
-    [ccButton.buttonSmallOverride]: small && !(secondary || utility),
-    [ccButton.buttonUtility]: utility && !quiet,
-    [ccButton.buttonSmallUtility]: small && utility,
+    [ccButton.buttonUtility]: utility,
+    [`${ccButton.buttonUtilitySizing} ${ccButton.buttonMediumFontSize}`]: utility && !small,
     [ccButton.buttonLink]: link,
     [ccButton.buttonPill]: pill,
+    [`${ccButton.buttonPillSizing} ${ccButton.buttonMediumFontSize}`]: pill && !small,
     [ccButton.buttonInProgress]: loading,
     [ccButton.buttonIsDisabled]: props.disabled,
     [ccButton.linkAsButton]: !!props.href,
+    // small sizing, all buttons
+    [ccButton.buttonSmallSecondary]: (buttonSecondaryDefault || secondary || buttonFlat) && small,
+    [ccButton.buttonSmallPrimary]: (primary || buttonDestructive || buttonDestructiveFlat ) && small,
+    [ccButton.buttonSmallUtility]: utility && small,
+    [ccButton.buttonSmallButtonPill]: pill && small,
+    [ccButton.buttonSmallButtonLink]: link && small,
   });
 
   return (

--- a/packages/button/stories/Button.stories.tsx
+++ b/packages/button/stories/Button.stories.tsx
@@ -245,7 +245,7 @@ export const Example = () => {
           className="mr-32"
           target="_blank"
         >
-          Disabled button utility
+          Disabled button utility small
         </Button>
       </div>
     </div>

--- a/packages/button/stories/Button.stories.tsx
+++ b/packages/button/stories/Button.stories.tsx
@@ -224,12 +224,33 @@ export const Example = () => {
         </Button>
         {/* @ts-ignore */}
         <Button
+          secondary
+          small
+          quiet
+          disabled
+          className="mr-32"
+          target="_blank"
+        >
+          Disabled small quiet secondary button
+        </Button>
+        {/* @ts-ignore */}
+        <Button
           primary
           disabled
           className="mr-32"
           target="_blank"
         >
           Disabled button primary
+        </Button>
+               {/* @ts-ignore */}
+               <Button
+          primary
+          small
+          disabled
+          className="mr-32"
+          target="_blank"
+        >
+          Disabled button small primary
         </Button>
         {/* @ts-ignore */}
         <Button

--- a/packages/button/stories/Button.stories.tsx
+++ b/packages/button/stories/Button.stories.tsx
@@ -28,6 +28,18 @@ export const Example = () => {
         <Button className="mr-32" primary small loading>
           Small Loading
         </Button>
+        {/* @ts-ignore */}
+        <Button className="mr-32" primary quiet>
+          Quiet
+        </Button>
+        {/* @ts-ignore */}
+        <Button className="mr-32" primary quiet small>
+          Quiet Small
+        </Button>
+        {/* @ts-ignore */}
+        <Button className="mr-32" primary quiet small loading>
+          Quiet Small Loading
+        </Button>
       </div>
       <div>
         <h3>Secondary</h3>
@@ -71,22 +83,22 @@ export const Example = () => {
         <h3>Negative</h3>
         {/* @ts-ignore */}
         <Button className="mr-32" negative>
-          Primary
+        Negative
         </Button>
         <Button className="mr-32" negative href="https://google.com">
           Simple href
         </Button>
         {/* @ts-ignore */}
         <Button className="mr-32" negative loading>
-          Primary Loading
+          Negative Loading
         </Button>
         {/* @ts-ignore */}
         <Button className="mr-32" negative small>
-          Primary Small
+          Negative Small
         </Button>
         {/* @ts-ignore */}
         <Button className="mr-32" negative small loading>
-          Primary Small Loading
+          Negative Small Loading
         </Button>
         {/* @ts-ignore */}
         <Button className="mr-32" negative quiet>

--- a/packages/button/stories/Button.stories.tsx
+++ b/packages/button/stories/Button.stories.tsx
@@ -18,7 +18,7 @@ export const Example = () => {
         </Button>
         {/* @ts-ignore */}
         <Button className="mr-32" primary loading>
-          Loading test
+          Loading
         </Button>
         {/* @ts-ignore */}
         <Button className="mr-32" primary small>
@@ -243,7 +243,7 @@ export const Example = () => {
           Disabled button primary
         </Button>
                {/* @ts-ignore */}
-               <Button
+        <Button
           primary
           small
           disabled

--- a/packages/button/stories/Button.stories.tsx
+++ b/packages/button/stories/Button.stories.tsx
@@ -18,7 +18,7 @@ export const Example = () => {
         </Button>
         {/* @ts-ignore */}
         <Button className="mr-32" primary loading>
-          Loading
+          Loading test
         </Button>
         {/* @ts-ignore */}
         <Button className="mr-32" primary small>
@@ -130,12 +130,20 @@ export const Example = () => {
         <Button className="mr-32" utility quiet>
           Quiet
         </Button>
+        {/* @ts-ignore */}
+        <Button className="mr-32" utility quiet small>
+          Quiet small
+        </Button>
       </div>
       <div>
         <h3>Pill</h3>
         {/* @ts-ignore */}
         <Button className="mr-32" pill>
-          Simple
+          Simple pill
+        </Button>
+        {/* @ts-ignore */}
+        <Button className="mr-32" pill small>
+          Simple small pill
         </Button>
         {/* @ts-ignore */}
         <Button className="mr-32" pill loading>
@@ -150,7 +158,7 @@ export const Example = () => {
         </Button>
         {/* @ts-ignore */}
         <Button className="mr-32" link small>
-          Loading
+          Simple link small
         </Button>
       </div>
       <div>
@@ -207,7 +215,6 @@ export const Example = () => {
           primary
           disabled
           className="mr-32"
-          href="https://google.com/"
           target="_blank"
         >
           Disabled button primary
@@ -217,7 +224,6 @@ export const Example = () => {
           negative
           disabled
           className="mr-32"
-          href="https://google.com/"
           target="_blank"
         >
           Disabled button negative
@@ -227,7 +233,16 @@ export const Example = () => {
           utility
           disabled
           className="mr-32"
-          href="https://google.com/"
+          target="_blank"
+        >
+          Disabled button utility
+        </Button>
+        {/* @ts-ignore */}
+        <Button
+          utility
+          disabled
+          small
+          className="mr-32"
           target="_blank"
         >
           Disabled button utility

--- a/packages/pill/stories/Button.stories.tsx
+++ b/packages/pill/stories/Button.stories.tsx
@@ -39,7 +39,7 @@ export const PillsWithIcon = () => {
   return (
     <div className="flex space-x-8">
       <Pill
-        icon={<IconSearch16 lang={lang}/>}
+        icon={<IconSearch16 />}
         onClick={() => alert('onClick event')}
         className="py-12"
       />

--- a/packages/pill/stories/Button.stories.tsx
+++ b/packages/pill/stories/Button.stories.tsx
@@ -39,7 +39,7 @@ export const PillsWithIcon = () => {
   return (
     <div className="flex space-x-8">
       <Pill
-        icon={<IconSearch16 />}
+        icon={<IconSearch16 lang={lang}/>}
         onClick={() => alert('onClick event')}
         className="py-12"
       />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: ^1.0.0
     version: 1.0.0
   '@warp-ds/css':
-    specifier: ^1.0.0
-    version: 1.0.0
+    specifier: ^1.0.1
+    version: 1.0.1
   '@warp-ds/uno':
     specifier: ^1.0.0
     version: 1.0.0
@@ -5757,8 +5757,8 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/css@1.0.0:
-    resolution: {integrity: sha512-rxzEBKl5g7RP+5S27+gwhceO6clMHiYfRbbaDmJVJMyUNU8JwfYoMovoeVlJLLK0yh/v7yOdmUpP8/tJqqcB5w==}
+  /@warp-ds/css@1.0.1:
+    resolution: {integrity: sha512-FeLaYSe6G5wcI1SENkbGrArEMPGmewwwCMgWQh1944iC3NgLXGWEx3ZRHcBNfiMJImpuZeaHSUOM3yozYbZvbw==}
     dependencies:
       '@warp-ds/fonts': 1.1.0
       '@warp-ds/tokenizer': 0.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5773,7 +5773,7 @@ packages:
     resolution: {integrity: sha512-pEtBvP6my14f1kOmYSoDNhofGK/L2yNqnZkEotvY6boVs3jcIncHpgo9Nt4AHOiAvzDrPP0t8b36jwqGaWzNPg==}
     dependencies:
       glob: 9.3.5
-      yaml: 2.3.1
+      yaml: 2.3.2
     dev: false
 
   /@warp-ds/uno@1.0.0:
@@ -10470,8 +10470,8 @@ packages:
     dependencies:
       js-tokens: 4.0.0
 
-  /lru-cache@10.0.0:
-    resolution: {integrity: sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==}
+  /lru-cache@10.0.1:
+    resolution: {integrity: sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==}
     engines: {node: 14 || >=16.14}
     dev: false
 
@@ -11581,7 +11581,7 @@ packages:
     resolution: {integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
-      lru-cache: 10.0.0
+      lru-cache: 10.0.1
       minipass: 5.0.0
     dev: false
 
@@ -14153,8 +14153,8 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
-  /yaml@2.3.1:
-    resolution: {integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==}
+  /yaml@2.3.2:
+    resolution: {integrity: sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==}
     engines: {node: '>= 14'}
     dev: false
 


### PR DESCRIPTION
One more try for button refactoring

In this case we add classes specifically for a button with all variants and such.

The code grew a lot. But I hope it is easier to follow and will improve our work when we will debug problems with buttons.

TODO:

- [x] Move everything to the css repo, ONLY kept here for testing purposes in the beginning (line 28-154 will be moved out)
~- [ ] Shortcuts (what it is in comments) will be fixed in the css repo~

PR for the classes and shortcuts: https://github.com/warp-ds/css/pull/44

First attempt [here](https://github.com/warp-ds/react/pull/66) but it was too unsafe but it is for sure less code but what is more important here 🤷 

- [x] THIS PR SHOULD ALSO BE OPENED TO NEXT BRANCH WHEN IT IS DONE
