### PR TITLE
chore: add workflow for publishing storybook

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,0 +1,20 @@
+name: Storybook
+on:
+  push:
+    branches:
+      - next
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install and Build
+        run: |
+          npm ci
+          npm run build-storybook
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: storybook-static


### PR DESCRIPTION
Steps done: 

1. Created the `gh-pages` branch
2. Set the source to target `gh-pages` and selected root folder here https://github.com/warp-ds/react/settings/pages
3. The output of the `pnpm run build-storybook` is pointed out as a folder for static storybook page

So hopefully when this PR is merged we will have our Storybook published here https://warp-ds.github.io/react/

It is now only triggered on the pushes to next but we can also add `main` to the list. Just wanted to test this one out first
