### PR TITLE
fix: add aria-current propp to the anchor element for e.g. pagination…

### DIFF
--- a/packages/button/src/component.tsx
+++ b/packages/button/src/component.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, Ref } from 'react';
+import React, { forwardRef, Ref, AnchorHTMLAttributes } from 'react';
 import { button as ccButton } from '@warp-ds/css/component-classes';
 import { i18n } from '@lingui/core';
 import { classNames } from '@chbphone55/classnames';
@@ -18,7 +18,7 @@ const buttonTypes = [
 ] as const;
 
 export const Button = forwardRef<
-  HTMLButtonElement | HTMLAnchorElement,
+  HTMLButtonElement | AnchorHTMLAttributes<HTMLAnchorElement>,
   ButtonProps
 >((props, ref) => {
   const {
@@ -111,6 +111,7 @@ export const Button = forwardRef<
     <>
       {props.href ? (
         <a
+          aria-current={props['aria-current']}
           href={props.href}
           target={props.target}
           rel={


### PR DESCRIPTION
… component


Team is trying to add `aria-current` to the button with href but the prop is not propagated 
<img width="649" alt="image" src="https://github.com/warp-ds/react/assets/37986637/c18034ea-a72a-4e07-ad45-a8d5c5937d8a">
