### PR TITLE
fix: add check for children in tabs

### DIFF
--- a/packages/tabs/src/component-tabs.tsx
+++ b/packages/tabs/src/component-tabs.tsx
@@ -146,9 +146,9 @@ export const Tabs = (props: TabsProps) => {
         onKeyDown={handleKeyDown}
       >
         {Children.map(children, (child: any) => {
-          return cloneElement(child, {
-            setActive: change,
-            isActive: child.props.name === active,
+          return child && cloneElement(child, {
+                setActive: change,
+                isActive: child?.props?.name === active,
           });
         })}
         {<span className={wunderbar} ref={wunderbarRef} />}

--- a/packages/tabs/stories/Tabs.stories.tsx
+++ b/packages/tabs/stories/Tabs.stories.tsx
@@ -27,7 +27,7 @@ export const Default = () => {
   return (
     <Tabs onChange={(e) => console.log(e)}>
       <Tab label="Tab 1" name="one" />
-      <Tab label="Tab 2" name="two" />
+      {false && <Tab label="Tab 2" name="two" />}
       <Tab label="Tab 3" name="three" isActive />
     </Tabs>
   );


### PR DESCRIPTION
Background: https://sch-chat.slack.com/archives/C04P0GYTHPV/p1694002177060589

Do not break when a child is falsy.

![image](https://github.com/warp-ds/react/assets/37986637/b586c0d1-f31d-43f5-bd8d-200b12634186)
![image](https://github.com/warp-ds/react/assets/37986637/75eebccb-84ed-4588-abd5-da083e4fe88c)
