### PR TITLE
fix(button): set secondary variant styles by default

### DIFF
--- a/packages/button/src/component.tsx
+++ b/packages/button/src/component.tsx
@@ -8,7 +8,7 @@ import { messages as nbMessages} from './locales/nb/messages.mjs';
 import { messages as fiMessages} from './locales/fi/messages.mjs';
 import { activateI18n } from '../../i18n';
 
-const buttonTypes = [    
+const buttonVariants = [
   'primary',
   'secondary',
   'negative',
@@ -34,21 +34,21 @@ export const Button = forwardRef<
     ...rest
   } = props;
 
-  const buttonType = buttonTypes.find(b => !!props[b]);
-  
+  const defaultVariant = secondary || !buttonVariants.find(b => !!props[b]);
+
   const classes = classNames(props.className, {
-    [ccButton.secondary]: (secondary || !buttonType) && !small && !quiet && !loading && !props.disabled,
-    [ccButton.secondaryDisabled]: (secondary || !buttonType) && !small && !quiet && !loading && props.disabled,
-    [ccButton.secondarySmall]: secondary && small && !quiet && !loading && !props.disabled,
-    [ccButton.secondarySmallDisabled]: secondary && small && !quiet && !loading && props.disabled,
-    [ccButton.secondarySmallLoading]: secondary && small && !quiet && loading,
-    [ccButton.secondarySmallQuiet]: secondary && small && quiet && !loading && !props.disabled,
-    [ccButton.secondarySmallQuietDisabled]: secondary && small && quiet && !loading && props.disabled,
-    [ccButton.secondarySmallQuietLoading]: secondary && small && quiet && loading,
-    [ccButton.secondaryQuiet]: secondary && !small && quiet && !loading && !props.disabled,
-    [ccButton.secondaryQuietDisabled]: secondary && !small && quiet && !loading && props.disabled,
-    [ccButton.secondaryQuietLoading]: secondary && !small && quiet && loading,
-    [ccButton.secondaryLoading]: secondary && !small && !quiet && loading,
+    [ccButton.secondary]: defaultVariant && !small && !quiet && !loading && !props.disabled,
+    [ccButton.secondaryDisabled]: defaultVariant && !small && !quiet && !loading && props.disabled,
+    [ccButton.secondarySmall]: defaultVariant && small && !quiet && !loading && !props.disabled,
+    [ccButton.secondarySmallDisabled]: defaultVariant && small && !quiet && !loading && props.disabled,
+    [ccButton.secondarySmallLoading]: defaultVariant && small && !quiet && loading,
+    [ccButton.secondarySmallQuiet]: defaultVariant && small && quiet && !loading && !props.disabled,
+    [ccButton.secondarySmallQuietDisabled]: defaultVariant && small && quiet && !loading && props.disabled,
+    [ccButton.secondarySmallQuietLoading]: defaultVariant && small && quiet && loading,
+    [ccButton.secondaryQuiet]: defaultVariant && !small && quiet && !loading && !props.disabled,
+    [ccButton.secondaryQuietDisabled]: defaultVariant && !small && quiet && !loading && props.disabled,
+    [ccButton.secondaryQuietLoading]: defaultVariant && !small && quiet && loading,
+    [ccButton.secondaryLoading]: defaultVariant && !small && !quiet && loading,
     
     [ccButton.primary]: primary && !small && !quiet && !loading && !props.disabled,
     [ccButton.primaryDisabled]: primary && !small && !quiet && !loading && props.disabled,


### PR DESCRIPTION
Fixes issues where buttons receiving only modifier props like `small`, `loading`, `quiet` (without any variant prop) weren't applying any classes. The default button variant in such case should be "secondary".

Also renamed `buttonTypes` to `buttonVariants` to align with [Warp Elements API](https://github.com/warp-ds/elements/blob/next/packages/button/index.js#L39) and to avoid confusion with another prop that is called `type`.

Before:
<img width="455" alt="Screenshot 2023-09-15 at 12 26 37" src="https://github.com/warp-ds/react/assets/41303231/83b3a3af-f096-43b5-ad72-f760bcb764bf">
<img width="1043" alt="Screenshot 2023-09-15 at 12 23 50" src="https://github.com/warp-ds/react/assets/41303231/73495729-b2ab-4cee-831b-7a802305ae61">

After:
<img width="441" alt="Screenshot 2023-09-15 at 12 26 31" src="https://github.com/warp-ds/react/assets/41303231/2e93f846-f6d9-470f-aff7-2b31eaf702ee">
<img width="1203" alt="Screenshot 2023-09-15 at 12 35 23" src="https://github.com/warp-ds/react/assets/41303231/1e219f09-49ae-49c0-85d4-64c27a18baf5">
