### PR TITLE
chore: reuse the workflow for crowdin sync

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -7,9 +7,8 @@ on:
 jobs:
   synchronize-with-crowdin:
     uses: warp-ds/reusable-workflows/.github/workflows/crowdin-sync.yml@main
-    with:
+    secrets:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
       CROWDIN_BASE_URL: ${{ vars.CROWDIN_BASE_URL }}
-    secrets:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CROWDIN_API_TOKEN: ${{ secrets.CROWDIN_API_TOKEN }}

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -2,7 +2,7 @@ name: Crowdin Synchronisation
 
 on:
   push:
-    branches: [next, main]
+    branches: [use-reusable-crowdin-workflow, next, main]
 
 jobs:
   synchronize-with-crowdin:

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -1,29 +1,9 @@
 name: Crowdin Synchronisation
 
-permissions:
-  contents: write
-  pull-requests: write
-
 on:
   push:
     branches: [next, main]
 
 jobs:
   synchronize-with-crowdin:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: crowdin action
-        uses: crowdin/github-action@v1
-        with:
-          upload_sources: true
-          upload_translations: true
-          download_translations: true
-          create_pull_request: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
-          CROWDIN_API_TOKEN: ${{ secrets.CROWDIN_API_TOKEN }}
-          CROWDIN_BASE_URL: ${{ vars.CROWDIN_BASE_URL }}
+    uses: warp-ds/reusable-workflows/.github/workflows/crowdin-sync.yml@main

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -1,4 +1,4 @@
-name: Crowdin Synchronisation
+name: Crowdin Synchronisation Trigger
 
 on:
   push:

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -7,3 +7,5 @@ on:
 jobs:
   synchronize-with-crowdin:
     uses: warp-ds/reusable-workflows/.github/workflows/crowdin-sync.yml@main
+    with:
+      config_file: "../../crowdin.yml"

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -7,3 +7,9 @@ on:
 jobs:
   synchronize-with-crowdin:
     uses: warp-ds/reusable-workflows/.github/workflows/crowdin-sync.yml@main
+    with:
+      CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
+      CROWDIN_BASE_URL: ${{ vars.CROWDIN_BASE_URL }}
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CROWDIN_API_TOKEN: ${{ secrets.CROWDIN_API_TOKEN }}

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -7,3 +7,4 @@ on:
 jobs:
   synchronize-with-crowdin:
     uses: warp-ds/reusable-workflows/.github/workflows/crowdin-sync.yml@main
+    secrets: inherit

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -7,5 +7,3 @@ on:
 jobs:
   synchronize-with-crowdin:
     uses: warp-ds/reusable-workflows/.github/workflows/crowdin-sync.yml@main
-    with:
-      config_name: "../../crowdin.yml"

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -8,4 +8,4 @@ jobs:
   synchronize-with-crowdin:
     uses: warp-ds/reusable-workflows/.github/workflows/crowdin-sync.yml@main
     with:
-      config_file: "../../crowdin.yml"
+      config_name: "../../crowdin.yml"

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -8,7 +8,7 @@ jobs:
   synchronize-with-crowdin:
     uses: warp-ds/reusable-workflows/.github/workflows/crowdin-sync.yml@main
     secrets:
-      CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
-      CROWDIN_BASE_URL: ${{ vars.CROWDIN_BASE_URL }}
+      CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+      CROWDIN_BASE_URL: ${{ secrets.CROWDIN_BASE_URL }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CROWDIN_API_TOKEN: ${{ secrets.CROWDIN_API_TOKEN }}

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -1,8 +1,8 @@
-name: Crowdin Synchronisation Trigger
+name: Crowdin Synchronisation
 
 on:
   push:
-    branches: [use-reusable-crowdin-workflow, next, main]
+    branches: [next, main]
 
 jobs:
   synchronize-with-crowdin:

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -7,8 +7,3 @@ on:
 jobs:
   synchronize-with-crowdin:
     uses: warp-ds/reusable-workflows/.github/workflows/crowdin-sync.yml@main
-    secrets:
-      CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
-      CROWDIN_BASE_URL: ${{ secrets.CROWDIN_BASE_URL }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CROWDIN_API_TOKEN: ${{ secrets.CROWDIN_API_TOKEN }}


### PR DESCRIPTION
To avoid the [a bigger amount of code to be added in every repo](https://github.com/warp-ds/vue/pull/65/files#diff-7209abc5864519d00079d00aa93b020b2bc820640edffdc93df1824a2cfc34a7) let's create a reusable workflow and call it to our workflow. We've done something simliar(but a composite action approach) for PR linter to avoid copy pasting the same code everywhere, and it is also easier to maintain in one place

Reusable workflow is created here https://github.com/warp-ds/reusable-workflows