### PR TITLE
fix(forms): localize 'optional' label in forms

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -42,9 +42,14 @@ files:
       "dest": "react/packages/textarea/messages.po",
       "translation": "/packages/textarea/src/locales/%two_letters_code%/messages.po",
     },
-        {
+    {
       "source": "/packages/textfield/src/locales/en/messages.po",
       "dest": "react/packages/textfield/messages.po",
       "translation": "/packages/textfield/src/locales/%two_letters_code%/messages.po",
+    },
+    {
+      "source": "/packages/select/src/locales/en/messages.po",
+      "dest": "react/packages/select/messages.po",
+      "translation": "/packages/select/src/locales/%two_letters_code%/messages.po",
     },
   ]

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -42,4 +42,9 @@ files:
       "dest": "react/packages/textarea/messages.po",
       "translation": "/packages/textarea/src/locales/%two_letters_code%/messages.po",
     },
+        {
+      "source": "/packages/textfield/src/locales/en/messages.po",
+      "dest": "react/packages/textfield/messages.po",
+      "translation": "/packages/textfield/src/locales/%two_letters_code%/messages.po",
+    },
   ]

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -52,4 +52,9 @@ files:
       "dest": "react/packages/select/messages.po",
       "translation": "/packages/select/src/locales/%two_letters_code%/messages.po",
     },
+    {
+      "source": "/packages/toggle/src/locales/en/messages.po",
+      "dest": "react/packages/toggle/messages.po",
+      "translation": "/packages/toggle/src/locales/%two_letters_code%/messages.po",
+    },
   ]

--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -36,6 +36,10 @@ const config: LinguiConfig = {
       include: ['packages/textfield/src/**/*.{ts,tsx}'],
       path: 'packages/textfield/src/locales/{locale}/messages',
     },
+    {
+      include: ['packages/select/src/**/*.{ts,tsx}'],
+      path: 'packages/select/src/locales/{locale}/messages',
+    },
   ],
   compileNamespace: 'es',
 };

--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -40,6 +40,10 @@ const config: LinguiConfig = {
       include: ['packages/select/src/**/*.{ts,tsx}'],
       path: 'packages/select/src/locales/{locale}/messages',
     },
+    {
+      include: ['packages/toggle/src/**/*.{ts,tsx}'],
+      path: 'packages/toggle/src/locales/{locale}/messages',
+    },
   ],
   compileNamespace: 'es',
 };

--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -32,6 +32,10 @@ const config: LinguiConfig = {
       include: ['packages/textarea/src/**/*.{ts,tsx}'],
       path: 'packages/textarea/src/locales/{locale}/messages',
     },
+    {
+      include: ['packages/textfield/src/**/*.{ts,tsx}'],
+      path: 'packages/textfield/src/locales/{locale}/messages',
+    },
   ],
   compileNamespace: 'es',
 };

--- a/packages/select/src/component.tsx
+++ b/packages/select/src/component.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
+import { i18n } from '@lingui/core';
 import { select as ccSelect, label as ccLabel, helpText as ccHelpText } from '@warp-ds/css/component-classes';
 import { useId } from '../../utils/src';
 import { classNames } from '@chbphone55/classnames';
 import type { SelectProps } from './props';
+import { messages as nbMessages} from './locales/nb/messages.mjs';
+import { messages as enMessages} from './locales/en/messages.mjs';
+import { messages as fiMessages} from './locales/fi/messages.mjs';
+import { activateI18n } from '../../i18n';
 
 const setup = (props) => {
   const {
@@ -18,6 +23,8 @@ const setup = (props) => {
     disabled,
     ...rest
   } = props;
+
+  activateI18n(enMessages, nbMessages, fiMessages);
 
   const helpId = hint ? `${id}__hint` : undefined;
 
@@ -83,7 +90,13 @@ function Select(props: SelectProps, ref: React.Ref<HTMLSelectElement>) {
           {label.children}
           {optional && (
             <span className={ccLabel.optional}>
-              (valgfritt)
+              {i18n._(
+                /*i18n*/ {
+                  id: 'select.label.optional',
+                  message: '(optional)',
+                  comment: 'Shown behind label when marked as optional',
+                },
+              )}
             </span>
           )}
         </label>

--- a/packages/select/src/locales/en/messages.mjs
+++ b/packages/select/src/locales/en/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"select.label.optional\":\"(optional)\"}");

--- a/packages/select/src/locales/en/messages.po
+++ b/packages/select/src/locales/en/messages.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-08-01 12:17+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. Shown behind label when marked as optional
+#. js-lingui-explicit-id
+#: packages/select/src/component.tsx:94
+msgid "select.label.optional"
+msgstr "(optional)"

--- a/packages/select/src/locales/fi/messages.mjs
+++ b/packages/select/src/locales/fi/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"select.label.optional\":\"(valinnainen)\"}");

--- a/packages/select/src/locales/fi/messages.po
+++ b/packages/select/src/locales/fi/messages.po
@@ -1,0 +1,25 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-08-01 12:17+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: fi\n"
+"Project-Id-Version: 2853b3c41d7b7a59e7cd64c0153b540a\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2023-09-11 14:59\n"
+"Last-Translator: \n"
+"Language-Team: Finnish\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-Project: 2853b3c41d7b7a59e7cd64c0153b540a\n"
+"X-Crowdin-Project-ID: 141\n"
+"X-Crowdin-Language: fi\n"
+"X-Crowdin-File: /react/packages/select/messages.po\n"
+"X-Crowdin-File-ID: 675\n"
+
+#. Shown behind label when marked as optional
+#. js-lingui-explicit-id
+#: packages/select/src/component.tsx:94
+msgid "select.label.optional"
+msgstr "(valinnainen)"

--- a/packages/select/src/locales/nb/messages.mjs
+++ b/packages/select/src/locales/nb/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"select.label.optional\":\"(valgfritt)\"}");

--- a/packages/select/src/locales/nb/messages.po
+++ b/packages/select/src/locales/nb/messages.po
@@ -1,0 +1,25 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-08-01 12:17+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: nb_NO\n"
+"Project-Id-Version: 2853b3c41d7b7a59e7cd64c0153b540a\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2023-09-11 14:59\n"
+"Last-Translator: \n"
+"Language-Team: Norwegian Bokmal\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-Project: 2853b3c41d7b7a59e7cd64c0153b540a\n"
+"X-Crowdin-Project-ID: 141\n"
+"X-Crowdin-Language: nb\n"
+"X-Crowdin-File: /react/packages/select/messages.po\n"
+"X-Crowdin-File-ID: 675\n"
+
+#. Shown behind label when marked as optional
+#. js-lingui-explicit-id
+#: packages/select/src/component.tsx:94
+msgid "select.label.optional"
+msgstr "(valgfritt)"

--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -1,8 +1,13 @@
 import React, { forwardRef } from 'react';
+import { i18n } from '@lingui/core';
 import { classNames } from '@chbphone55/classnames';
 import { input as ccInput, label as ccLabel, helpText as ccHelpText } from '@warp-ds/css/component-classes';
 import { useId } from '../../utils/src';
 import { TextFieldProps } from './props';
+import { messages as nbMessages} from './locales/nb/messages.mjs';
+import { messages as enMessages} from './locales/en/messages.mjs';
+import { messages as fiMessages} from './locales/fi/messages.mjs';
+import { activateI18n } from '../../i18n';
 
 export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
   (props, ref) => {
@@ -21,6 +26,8 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       optional,
       ...rest
     } = props;
+
+    activateI18n(enMessages, nbMessages, fiMessages);
 
     const id = useId(providedId);
 
@@ -47,7 +54,13 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
               {label}
               {optional && (
                 <span className={ccLabel.optional}>
-                  (valgfritt)
+                  {i18n._(
+                    /*i18n*/ {
+                      id: 'textfield.label.optional',
+                      message: '(optional)',
+                      comment: 'Shown behind label when marked as optional',
+                    },
+                  )}
                 </span>
               )}
             </label>

--- a/packages/textfield/src/locales/en/messages.mjs
+++ b/packages/textfield/src/locales/en/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"textfield.label.optional\":\"(optional)\"}");

--- a/packages/textfield/src/locales/en/messages.po
+++ b/packages/textfield/src/locales/en/messages.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-08-01 12:17+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. Shown behind label when marked as optional
+#. js-lingui-explicit-id
+#: packages/textfield/src/component.tsx:58
+msgid "textfield.label.optional"
+msgstr "(optional)"

--- a/packages/textfield/src/locales/fi/messages.mjs
+++ b/packages/textfield/src/locales/fi/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"textfield.label.optional\":\"(valinnainen)\"}");

--- a/packages/textfield/src/locales/fi/messages.po
+++ b/packages/textfield/src/locales/fi/messages.po
@@ -1,0 +1,25 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-08-01 12:17+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: fi\n"
+"Project-Id-Version: 2853b3c41d7b7a59e7cd64c0153b540a\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2023-09-11 14:59\n"
+"Last-Translator: \n"
+"Language-Team: Finnish\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-Project: 2853b3c41d7b7a59e7cd64c0153b540a\n"
+"X-Crowdin-Project-ID: 141\n"
+"X-Crowdin-Language: fi\n"
+"X-Crowdin-File: /react/packages/textfield/messages.po\n"
+"X-Crowdin-File-ID: 675\n"
+
+#. Shown behind label when marked as optional
+#. js-lingui-explicit-id
+#: packages/textfield/src/component.tsx:58
+msgid "textfield.label.optional"
+msgstr "(valinnainen)"

--- a/packages/textfield/src/locales/nb/messages.mjs
+++ b/packages/textfield/src/locales/nb/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"textfield.label.optional\":\"(valgfritt)\"}");

--- a/packages/textfield/src/locales/nb/messages.po
+++ b/packages/textfield/src/locales/nb/messages.po
@@ -1,0 +1,25 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-08-01 12:17+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: nb_NO\n"
+"Project-Id-Version: 2853b3c41d7b7a59e7cd64c0153b540a\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2023-09-11 14:59\n"
+"Last-Translator: \n"
+"Language-Team: Norwegian Bokmal\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-Project: 2853b3c41d7b7a59e7cd64c0153b540a\n"
+"X-Crowdin-Project-ID: 141\n"
+"X-Crowdin-Language: nb\n"
+"X-Crowdin-File: /react/packages/textfield/messages.po\n"
+"X-Crowdin-File-ID: 675\n"
+
+#. Shown behind label when marked as optional
+#. js-lingui-explicit-id
+#: packages/textfield/src/component.tsx:58
+msgid "textfield.label.optional"
+msgstr "(valgfritt)"

--- a/packages/toggle/src/component.tsx
+++ b/packages/toggle/src/component.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
+import { i18n } from '@lingui/core';
 import { label as ccLabel, helpText as ccHelpText, toggle as ccToggle } from '@warp-ds/css/component-classes';
 import { useId } from '../../utils/src';
 import { ToggleEntry, ToggleProps } from './props';
 import { classNames } from '@chbphone55/classnames';
 import { Item } from './item';
+import { messages as nbMessages} from './locales/nb/messages.mjs';
+import { messages as enMessages} from './locales/en/messages.mjs';
+import { messages as fiMessages} from './locales/fi/messages.mjs';
+import { activateI18n } from '../../i18n';
 
 function Title({ id, isInvalid, title, optional }) {
+  activateI18n(enMessages, nbMessages, fiMessages);
+
   return (
     <legend
       id={`${id}__title`}
@@ -17,7 +24,13 @@ function Title({ id, isInvalid, title, optional }) {
       {title}
       {optional && (
         <span className={ccLabel.optional}>
-          (valgfritt)
+          {i18n._(
+            /*i18n*/ {
+              id: 'toggle.label.optional',
+              message: '(optional)',
+              comment: 'Shown behind label when marked as optional',
+            },
+          )}
         </span>
       )}
     </legend>

--- a/packages/toggle/src/locales/en/messages.mjs
+++ b/packages/toggle/src/locales/en/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"toggle.label.optional\":\"(optional)\"}");

--- a/packages/toggle/src/locales/en/messages.po
+++ b/packages/toggle/src/locales/en/messages.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-08-01 12:17+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. Shown behind label when marked as optional
+#. js-lingui-explicit-id
+#: packages/toggle/src/component.tsx:28
+msgid "toggle.label.optional"
+msgstr "(optional)"

--- a/packages/toggle/src/locales/fi/messages.mjs
+++ b/packages/toggle/src/locales/fi/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"toggle.label.optional\":\"(valinnainen)\"}");

--- a/packages/toggle/src/locales/fi/messages.po
+++ b/packages/toggle/src/locales/fi/messages.po
@@ -1,0 +1,25 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-08-01 12:17+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: fi\n"
+"Project-Id-Version: 2853b3c41d7b7a59e7cd64c0153b540a\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2023-09-11 14:59\n"
+"Last-Translator: \n"
+"Language-Team: Finnish\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-Project: 2853b3c41d7b7a59e7cd64c0153b540a\n"
+"X-Crowdin-Project-ID: 141\n"
+"X-Crowdin-Language: fi\n"
+"X-Crowdin-File: /react/packages/toggle/messages.po\n"
+"X-Crowdin-File-ID: 675\n"
+
+#. Shown behind label when marked as optional
+#. js-lingui-explicit-id
+#: packages/toggle/src/component.tsx:28
+msgid "toggle.label.optional"
+msgstr "(valinnainen)"

--- a/packages/toggle/src/locales/nb/messages.mjs
+++ b/packages/toggle/src/locales/nb/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"toggle.label.optional\":\"(valgfritt)\"}");

--- a/packages/toggle/src/locales/nb/messages.po
+++ b/packages/toggle/src/locales/nb/messages.po
@@ -1,0 +1,25 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-08-01 12:17+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: nb_NO\n"
+"Project-Id-Version: 2853b3c41d7b7a59e7cd64c0153b540a\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2023-09-11 14:59\n"
+"Last-Translator: \n"
+"Language-Team: Norwegian Bokmal\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-Project: 2853b3c41d7b7a59e7cd64c0153b540a\n"
+"X-Crowdin-Project-ID: 141\n"
+"X-Crowdin-Language: nb\n"
+"X-Crowdin-File: /react/packages/toggle/messages.po\n"
+"X-Crowdin-File-ID: 675\n"
+
+#. Shown behind label when marked as optional
+#. js-lingui-explicit-id
+#: packages/toggle/src/component.tsx:28
+msgid "toggle.label.optional"
+msgstr "(valgfritt)"

--- a/packages/toggle/src/props.ts
+++ b/packages/toggle/src/props.ts
@@ -66,7 +66,7 @@ export interface ToggleProps {
 
   /**
    * Whether the toggle is optional
-   * Appends (valgfritt) to the end of the title for indication
+   * Appends localized '(optional)' to the end of the title for indication
    */
   optional?: boolean;
 


### PR DESCRIPTION
Optional label in Toggle, TextField and Select will now also show different language versions depending on `lang` attribute of document's html tag.

**Toggle (Finnish):**
<img width="203" alt="Screenshot 2023-10-06 at 14 03 02" src="https://github.com/warp-ds/react/assets/41303231/e016191b-0519-42b8-a689-a46800183397">
**TextField (Finnish, English, Norwegian):**
<img width="205" alt="Screenshot 2023-10-06 at 13 42 37" src="https://github.com/warp-ds/react/assets/41303231/24bb71fb-53ee-4dcf-8e46-57b9ed451416"><img width="186" alt="Screenshot 2023-10-06 at 13 42 51" src="https://github.com/warp-ds/react/assets/41303231/58763a48-975e-4d29-87f2-999202bfa010"><img width="192" alt="Screenshot 2023-10-06 at 14 10 40" src="https://github.com/warp-ds/react/assets/41303231/2089da25-b23a-4e7b-950a-b1c5ecd0ab47">

**Select (Finnish):**
<img width="215" alt="Screenshot 2023-10-06 at 13 50 13" src="https://github.com/warp-ds/react/assets/41303231/df5c80b4-66c7-45ca-9658-51d8d7d7d050">
