### PR TITLE
docs(alert): fix accessibility issues and add more examples to stories

### DIFF
--- a/packages/alert/src/props.tsx
+++ b/packages/alert/src/props.tsx
@@ -17,4 +17,8 @@ export type AlertProps = {
   className?: string;
   /** Additional CSS styles for the container. */
   style?: React.CSSProperties;
+  /**
+   * id used for relationship ARIA attributes
+   */
+  id?: string;
 };

--- a/packages/alert/stories/Alert.stories.tsx
+++ b/packages/alert/stories/Alert.stories.tsx
@@ -1,51 +1,43 @@
 import React from 'react';
 import { Button } from '../../button/src';
-import { Alert } from '../src';
+import { Alert, AlertProps } from '../src';
 
 const metadata = { title: 'FeedbackIndicators/Alert' };
 export default metadata;
 
-export const Default = () => {
-  const [show, setShow] = React.useState(true);
-
-  return (
-    <div className="flex flex-col gap-y-16">
-      <div>
-        <h3>Negative</h3>
-        <Alert type="negative" show={show}>
-          This is a message that you've done something really wrong.
-        </Alert>
-        <Button className="mt-16" small primary onClick={() => setShow(!show)}>
-          {show ? 'Hide negative alert' : 'Show negative alert'}
-        </Button>
-      </div>
-      <div>
-        <h3>Positive</h3>
-        <Alert type="positive" show>
-          This is a message that gives you positive feedback.
-        </Alert>
-      </div>
-      <div>
-        <h3>Warning</h3>
-        <Alert type="warning" show>
-          This is a message that shows a warning, might be nothing serious.
-        </Alert>
-      </div>
-      <div>
-        <h3>Info</h3>
-        <Alert type="info" show>
-          This is a message that enlightens you with some new cool information.
-        </Alert>
-      </div>
+export const Variants = () => (
+  <div className="flex flex-col gap-y-16">
+    <div>
+      <h3>Negative</h3>
+      <Alert type="negative" show>
+        This is "negative" variant of the alert component
+      </Alert>
     </div>
-  );
-};
+    <div>
+      <h3>Positive</h3>
+      <Alert type="positive" show role="status">
+        This is "positive" variant of the alert component
+      </Alert>
+    </div>
+    <div>
+      <h3>Warning</h3>
+      <Alert type="warning" show>
+        This is "warning" variant of the alert component
+      </Alert>
+    </div>
+    <div>
+      <h3>Info</h3>
+      <Alert type="info" show role="status">
+        This is "info" variant of the alert component
+      </Alert>
+    </div>
+  </div>
+);
 
-const InteractiveContent = () => (
+const InteractiveContent = ({type}: Pick<AlertProps, "type">) => (
   <>
-    <p className="font-bold">This text attracts your attention right away</p>
-    <p>This is the message text that can be short or a little bit long</p>
-    <a>Link to more information</a>
+    <h4 className="h5">This is {type} variant of the alert component</h4>
+    <p>With an additional description</p>
     <div className="mt-8 space-x-8">
       <Button small>Primary CTA</Button>
       <Button small secondary quiet>
@@ -55,38 +47,80 @@ const InteractiveContent = () => (
   </>
 );
 
-export const WithInteractiveContent = () => {
+export const WithInteractiveContent = () => (
+  <div className="flex flex-col gap-y-16">
+    <div>
+      <h3>Negative</h3>
+      <Alert type="negative" show>
+        <InteractiveContent type="negative"/>
+      </Alert>
+    </div>
+    <div>
+      <h3>Positive</h3>
+      <Alert type="positive" show role="status">
+        <InteractiveContent type="positive" />
+      </Alert>
+    </div>
+    <div>
+      <h3>Warning</h3>
+      <Alert type="warning" show>
+        <InteractiveContent type="warning"/>
+      </Alert>
+    </div>
+    <div>
+      <h3>Info</h3>
+      <Alert type="info" show role="status">
+        <InteractiveContent type="info"/>
+      </Alert>
+    </div>
+  </div>
+);
+
+export const WithDefaultRole = () => {
   const [show, setShow] = React.useState(true);
 
   return (
-    <div className="flex flex-col gap-y-16">
-      <div>
-        <h3>Negative</h3>
-        <Alert type="negative" show={show}>
-          <InteractiveContent />
-        </Alert>
-        <Button className="mt-16" small primary onClick={() => setShow(!show)}>
+    <>
+      <h3>Example with default role="alert"</h3>
+      <Button
+          className="mb-16"
+          small
+          primary
+          onClick={() => {setShow(!show)}}
+          aria-controls="negative-alert"
+          aria-expanded={show}
+        >
           {show ? 'Hide negative alert' : 'Show negative alert'}
         </Button>
-      </div>
-      <div>
-        <h3>Positive</h3>
-        <Alert type="positive" show>
-          <InteractiveContent />
-        </Alert>
-      </div>
-      <div>
-        <h3>Warning</h3>
-        <Alert type="warning" show>
-          <InteractiveContent />
-        </Alert>
-      </div>
-      <div>
-        <h3>Info</h3>
-        <Alert type="info" show>
-          <InteractiveContent />
-        </Alert>
-      </div>
-    </div>
+
+      <Alert id="negative-alert" type="negative" show={show}>
+        <h4 className="h5">This is "negative" variant of the alert component</h4>
+        <p>With an additional description</p>
+      </Alert>
+    </>
+  );
+}
+
+export const WithOverriddenRole = () => {
+  const [show, setShow] = React.useState(true);
+
+  return (
+    <>
+      <h3>Example with role="alert" on a descendant element</h3>
+      <Button
+        className="mb-16"
+        small
+        primary
+        onClick={() => {setShow(!show)}}
+        aria-controls="overriden-role-example-alert"
+        aria-expanded={show}
+      >
+        {show ? 'Hide warning alert' : 'Show warning alert'}
+      </Button>
+      <Alert id="overriden-role-example-alert" type="warning" show={show} role="">
+        <h4 className="h5">This is "warning" variant of the alert component</h4>
+        <p>With an additional description that is not that important</p>
+      </Alert>
+    </>
   );
 };


### PR DESCRIPTION
Fixes issues mentioned in [Warp-319](https://nmp-jira.atlassian.net/browse/WARP-319)

Stories are now grouped in the following way:
- all variants with and without interactive content
- expandable example with default role="alert" (for screen reader testing)
- expandable example with role="alert" on a descendant element (for screen reader testing)

Additional examples come from [./alert/docs/Alert.mdx](https://github.com/warp-ds/react/blob/next/packages/alert/docs/Alert.mdx).
![alert-examples](https://github.com/warp-ds/react/assets/41303231/9ffc6138-3a28-4ca3-a655-c20a9cee4a55)
