### PR TITLE
fix: ay11 fixes for the Modal component and affected stories

### DIFF
--- a/packages/modal/src/component.tsx
+++ b/packages/modal/src/component.tsx
@@ -22,6 +22,7 @@ export const Modal = ({
 }: ModalProps) => {
   const contentRef = useRef<HTMLDivElement>(null);
   const id = useId(props.id);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   activateI18n(enMessages, nbMessages, fiMessages);
 
@@ -32,9 +33,12 @@ export const Modal = ({
   }, [props.open, contentRef]);
 
   useEffect(() => {
-    if (!props.initialFocusRef) return;
-    props.initialFocusRef.current?.focus();
-  }, [props.open, props.initialFocusRef]);
+    if (!props.initialFocusRef) {
+      props.right && closeButtonRef.current?.focus();
+    } else {
+      props.initialFocusRef.current?.focus();
+    }
+  }, [props.open, props.initialFocusRef, closeButtonRef]);
 
   if (!props.open) return <></>;
 
@@ -109,7 +113,7 @@ export const Modal = ({
               )}
             >
               {typeof props.title === "string" ? (
-                <p className={ccModal.titleText}>{props.title}</p>
+                <h2 className={ccModal.titleText}>{props.title}</h2>
               ) : (
                 props.title
               )}
@@ -117,6 +121,7 @@ export const Modal = ({
 
             {typeof props.right === "boolean" && props.right ? (
               <button
+                ref={closeButtonRef}
                 type="button"
                 aria-label={i18n._(
                   /*i18n*/ {

--- a/packages/modal/src/component.tsx
+++ b/packages/modal/src/component.tsx
@@ -38,7 +38,7 @@ export const Modal = ({
     } else {
       props.initialFocusRef.current?.focus();
     }
-  }, [props.open, props.initialFocusRef, closeButtonRef]);
+  }, [props.open, props.initialFocusRef, props.right]);
 
   if (!props.open) return <></>;
 

--- a/packages/modal/src/component.tsx
+++ b/packages/modal/src/component.tsx
@@ -113,7 +113,7 @@ export const Modal = ({
               )}
             >
               {typeof props.title === "string" ? (
-                <h2 className={ccModal.titleText}>{props.title}</h2>
+                <h1 className={ccModal.titleText}>{props.title}</h1>
               ) : (
                 props.title
               )}

--- a/packages/modal/stories/Modal.stories.tsx
+++ b/packages/modal/stories/Modal.stories.tsx
@@ -9,10 +9,17 @@ export default metadata;
 export const Example = () => {
   const [open, setOpen] = React.useState(true);
   const toggleModal = () => setOpen(!open);
+  const openModalRef = React.useRef<HTMLButtonElement>(null);
+
+  React.useEffect(() => {
+    if (!open) {
+      openModalRef.current?.focus();
+    }
+  }, [open]);
 
   return (
     <>
-      <Button utility onClick={toggleModal}>
+      <Button ref={openModalRef} utility onClick={toggleModal}>
         Open modal
       </Button>
       <Modal
@@ -45,10 +52,17 @@ export const Example = () => {
 export const WithBackAndCloseButton = () => {
   const [open, setOpen] = React.useState(true);
   const toggleModal = () => setOpen(!open);
+  const openModalRef = React.useRef<HTMLButtonElement>(null);
+
+  React.useEffect(() => {
+    if (!open) {
+      openModalRef.current?.focus();
+    }
+  }, [open]);
 
   return (
     <>
-      <Button utility onClick={toggleModal}>
+      <Button ref={openModalRef} utility onClick={toggleModal}>
         Open modal
       </Button>
       <Modal
@@ -83,11 +97,19 @@ export const WithBackAndCloseButton = () => {
 export const MustConfirmToProceed = () => {
   const [open, setOpen] = React.useState(false);
   const [checked, setChecked] = React.useState(false);
+  const openModalRef = React.useRef<HTMLButtonElement>(null);
+
+  React.useEffect(() => {
+    if (!open) {
+      setChecked(false);
+      openModalRef.current?.focus();
+    }
+  }, [open]);
 
   const toggleModal = () => setOpen(!open);
   return (
     <>
-      <Button utility onClick={toggleModal}>
+      <Button ref={openModalRef} utility onClick={toggleModal}>
         Open modal
       </Button>
       <Modal
@@ -111,11 +133,17 @@ export const InitialFocus = () => {
   const [open, setOpen] = React.useState(false);
   const toggleModal = () => setOpen(!open);
 
-  const focusRef = React.useRef();
+  const focusRef = React.useRef<HTMLButtonElement>();
+  const openModalRef = React.useRef<HTMLButtonElement>(null);
 
+  React.useEffect(() => {
+    if (!open) {
+      openModalRef.current?.focus();
+    }
+  }, [open]);
   return (
     <>
-      <Button utility onClick={toggleModal}>
+      <Button ref={openModalRef} utility onClick={toggleModal}>
         Open modal
       </Button>
       <Modal
@@ -149,10 +177,16 @@ export const InitialFocus = () => {
 export const Overflowing = () => {
   const [open, setOpen] = React.useState(true);
   const toggleModal = () => setOpen(!open);
+  const openModalRef = React.useRef<HTMLButtonElement>(null);
+  React.useEffect(() => {
+    if (open) {
+      openModalRef.current?.focus();
+    }
+  }, [open]);
 
   return (
     <>
-      <Button utility onClick={toggleModal}>
+      <Button ref={openModalRef} utility onClick={toggleModal}>
         Open modal
       </Button>
       <Modal


### PR DESCRIPTION
Background: https://nmp-jira.atlassian.net/jira/software/projects/WARP/boards/15?label=web&selectedIssue=WARP-321

Fixes in the component: 
- exchange `p` with `h1`
- if close button - set focus on it instead of the first interactive element. This change needs to be reflected in the docs. See 👇 
![image](https://github.com/warp-ds/react/assets/37986637/f8312a2c-3dfc-4051-9d9f-e43cba898c69)

Fixes in stories:
- focus on the "Open modal" button
- reset checked on modal close
- initial focus visible