### PR TITLE
fix: warp-327 Accessability pass

### DIFF
--- a/packages/breadcrumbs/src/component.tsx
+++ b/packages/breadcrumbs/src/component.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import type { BreadcrumbsProps } from './props';
 import { interleave } from '@warp-ds/core/breadcrumbs';
-import { breadcrumbs as ccBreadcrumbs } from "@warp-ds/css/component-classes";
+import { breadcrumbs as ccBreadcrumbs } from '@warp-ds/css/component-classes';
 import { i18n } from '@lingui/core';
-import { messages as enMessages} from './locales/en/messages.mjs';
-import { messages as nbMessages} from './locales/nb/messages.mjs';
-import { messages as fiMessages} from './locales/fi/messages.mjs';
+import { messages as enMessages } from './locales/en/messages.mjs';
+import { messages as nbMessages } from './locales/nb/messages.mjs';
+import { messages as fiMessages } from './locales/fi/messages.mjs';
 import { activateI18n } from '../../i18n';
 
 export const Breadcrumbs = (props: BreadcrumbsProps) => {
@@ -13,44 +13,60 @@ export const Breadcrumbs = (props: BreadcrumbsProps) => {
 
   activateI18n(enMessages, nbMessages, fiMessages);
 
-  const ariaLabel = props['aria-label'] || i18n._(
-    /*i18n*/ {
-      id: 'breadcrumbs.ariaLabel',
-      message: 'You are here',
-      comment: 'Default screenreader message for the breadcrumb component',
-    });
+  const ariaLabel =
+    props['aria-label'] ||
+    i18n._(
+      /*i18n*/ {
+        id: 'breadcrumbs.ariaLabel',
+        message: 'You are here',
+        comment:
+          'Default screenreader message for the breadcrumb component',
+      }
+    );
 
   // Handles arrays of nodes passed as children
   const flattenedChildren = children.flat(Infinity);
   const styledChildren = flattenedChildren.map((child, index) => {
-      if (React.isValidElement(child)) {
-        const ccClasses = child.type === "a" ? ccBreadcrumbs.link : ccBreadcrumbs.text;
-        const newClasses = child.props.className ? `${child.props.className} ${ccClasses}` : ccClasses;
+    if (React.isValidElement(child)) {
+      const ccClasses =
+        child.type === 'a' ? ccBreadcrumbs.link : ccBreadcrumbs.text;
+      const newClasses = child.props.className
+        ? `${child.props.className} ${ccClasses}`
+        : ccClasses;
 
-       // To update a prop on React child element, we need to clone that Element first
-        const styledChild = React.cloneElement(child as React.ReactElement, { className: newClasses });
-        return styledChild;
-      }
-
-      const isLastEl = index === flattenedChildren.length - 1;
-
-      return <span className={ccBreadcrumbs.text} aria-current={isLastEl ? "page" : undefined}>{child}</span>;
+      // To update a prop on React child element, we need to clone that Element first
+      const styledChild = React.cloneElement(
+        child as React.ReactElement,
+        { className: newClasses }
+      );
+      return styledChild;
     }
-  )
+
+    const isLastEl = index === flattenedChildren.length - 1;
+
+    return (
+      <span
+        className={ccBreadcrumbs.text}
+        aria-current={isLastEl ? 'page' : undefined}
+      >
+        {child}
+      </span>
+    );
+  });
 
   return (
     <nav
       className={className}
-      aria-label={ariaLabel}
+      aria-labelledby="breadCrumbLabel"
       {...rest}
     >
-      <h2 className={ccBreadcrumbs.a11y}>{ariaLabel}</h2>
+      <h2 id="breadCrumbLabel" className={ccBreadcrumbs.a11y}>
+        {ariaLabel}
+      </h2>
       <div className={ccBreadcrumbs.wrapper}>
         {interleave(
           styledChildren,
-          <span aria-hidden className={ccBreadcrumbs.separator}>
-            /
-          </span>,
+          <span className={ccBreadcrumbs.separator}>/</span>
         ).map((element, index) => (
           <React.Fragment key={index}>{element}</React.Fragment>
         ))}


### PR DESCRIPTION
- Fixed the double Aria label
- Removed the aria-hidden from seperators

<img width="1687" alt="image" src="https://github.com/warp-ds/react/assets/462825/4f635f02-a4b7-4544-9ec2-f666f68aaa95">

This component assumes there is only one Breadcrumb on any single page. We should prob. not make assumptions like this anymore in any of or components and perhaps look into as separate tasks: 
- Random key gen all(?) ID's  (as in moving/modernizing this <code>@warp-ds/elements/packages/utils/index.js</code> <code>generateRandomId()</code> to a broader warp toolbox )
- Accept a root heading level if supplied to the component (we prob need to modernize the <code>unstyled-heading.js</code> script for this)