### PR TITLE
fix: a11y fixes for button link and link as buttons

### DIFF
--- a/packages/button/src/component.tsx
+++ b/packages/button/src/component.tsx
@@ -122,7 +122,7 @@ export const Button = forwardRef<
         <a
           onClick={handleClick}
           aria-current={props['aria-current']}
-          href={props.href}
+          href={props.disabled ? undefined : props.href}
           target={props.target}
           rel={
             props.target === '_blank'
@@ -131,6 +131,8 @@ export const Button = forwardRef<
           }
           ref={ref as Ref<HTMLAnchorElement>}
           className={classes}
+          role='button'
+          aria-disabled={props.disabled}
         >
           {props.children}
         </a>
@@ -140,6 +142,7 @@ export const Button = forwardRef<
           type={props.type || 'button'}
           ref={ref as Ref<HTMLButtonElement>}
           className={classes}
+          role={props.link ? 'link' : 'button'}
         >
           {props.children}
         </button>


### PR DESCRIPTION
Background: https://nmp-jira.atlassian.net/jira/software/projects/WARP/boards/15?selectedIssue=WARP-331

- [x] disable `link` that looks like a button
- [x] add `role=button` if a link is styled like a button
- [x] add `role=link` if a button looks like a link