### PR TITLE
chore: remove bad practice of opening in the new window in the Tabs story

### DIFF
--- a/packages/tabs/stories/Tabs.stories.tsx
+++ b/packages/tabs/stories/Tabs.stories.tsx
@@ -32,7 +32,7 @@ export const DefaultWithPanel = () => {
   );
 };
 
-export const DefaultWithExternalLinks = () => {
+export const DefaultWithOnClickAction = () => {
   return (
     <>
       <Tabs>
@@ -40,12 +40,12 @@ export const DefaultWithExternalLinks = () => {
         <Tab
           label="Tab 2 (www.finn.no)"
           name="two"
-          onClick={(e) => window.open("https://www.finn.no/", "_blank")}
+          onClick={() => alert('opened tab 2')}
         />
         <Tab
           label="Tab 3 (www.schibsted.com without panel)"
           name="three"
-          onClick={(e) => window.open("https://www.schibsted.com/", "_blank")}
+          onClick={() => alert('opened tab 3')}
         />
       </Tabs>
       <div className="mb-16">


### PR DESCRIPTION
Background: https://nmp-jira.atlassian.net/jira/software/projects/WARP/boards/15?label=web&selectedIssue=WARP-330
More related background 👇 
```
When a link automatically opens a new window or tab, it can be disorienting, especially for people who have difficulty visually perceiving content and for users with certain cognitive disabilities.

If a link opens a new tab or window without warning, people who are blind or visually impaired and use a screen reader to navigate will likely not realize that a new window or tab has opened and, as a result, will not know where they are and how to get back to the previous page.
```

We remove bad practice from our story.

