### PR TITLE
fix: anchor text alignment & icon translations

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -3,5 +3,5 @@
 <link rel="stylesheet" href="https://assets.finn.no/pkg/@warp-ds/css/v1/resets.css" />
 
 <script>
-  document.documentElement.setAttribute("lang", 'nb');
+  document.documentElement.setAttribute("lang", 'en');
 </script>

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@chbphone55/classnames": "^2.0.0",
     "@lingui/core": "^4.3.0",
     "@warp-ds/core": "^1.0.0",
-    "@warp-ds/css": "^1.1.1",
+    "@warp-ds/css": "^1.1.2",
     "@warp-ds/uno": "^1.1.0",
     "@warp-ds/icons": "1.1.0",
     "react-focus-lock": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@warp-ds/core": "^1.0.0",
     "@warp-ds/css": "^1.1.1",
     "@warp-ds/uno": "^1.1.0",
-    "@warp-ds/icons": "1.1.0-next.12",
+    "@warp-ds/icons": "1.1.0",
     "react-focus-lock": "^2.5.2",
     "resize-observer-polyfill": "^1.5.1",
     "scroll-doctor": "^1.0.0"

--- a/packages/button/stories/Button.stories.tsx
+++ b/packages/button/stories/Button.stories.tsx
@@ -297,6 +297,12 @@ export const Example = () => {
           Full width
         </Button>
       </div>
+      <div>
+        <h3>Full width link (href) styled as button</h3>
+        <Button fullWidth className="mr-32" primary href="https://google.com/">
+          Go to google.com
+        </Button>
+      </div>
     </div>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ dependencies:
     specifier: ^1.1.1
     version: 1.1.1
   '@warp-ds/icons':
-    specifier: 1.1.0-next.12
-    version: 1.1.0-next.12
+    specifier: 1.1.0
+    version: 1.1.0
   '@warp-ds/uno':
     specifier: ^1.1.0
     version: 1.1.0
@@ -5830,8 +5830,8 @@ packages:
     resolution: {integrity: sha512-kLNZzK3o0rMJApm7/YT3K7rYoFKgH5PyJMTVwv34O4Dx6ikfN7appc4f2DFYkE2XY6gifpD5F2r1ftcJtdW4+w==}
     dev: false
 
-  /@warp-ds/icons@1.1.0-next.12:
-    resolution: {integrity: sha512-wj0lStq1j5yqlK3G5AZUS5R9uFZVo01rdk3mwilYVsQRoa/xu10L7eQZJluY6pG5jItPmXal/wswZTrWNnpB0A==}
+  /@warp-ds/icons@1.1.0:
+    resolution: {integrity: sha512-2EJhU6L2nhaM3iTC9uApe5KU5/Pb5oNC6UncClfo5VMSjBzUn4RNkwyiyJlk4FrL41P7kre30M+VXpr+3KclFA==}
     dependencies:
       '@lingui/core': 4.5.0
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: ^1.0.0
     version: 1.0.0
   '@warp-ds/css':
-    specifier: ^1.1.1
-    version: 1.1.1
+    specifier: ^1.1.2
+    version: 1.1.2
   '@warp-ds/icons':
     specifier: 1.1.0
     version: 1.1.0
@@ -5818,16 +5818,11 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/css@1.1.1:
-    resolution: {integrity: sha512-xki6RMW9tO1jknPSkBNsWNlU/ADcGUOj4rlMfTBgOm7phwsI9kHd64zxI/29Xuh3dVE+ah7x9BIB0TxoZonSKA==}
+  /@warp-ds/css@1.1.2:
+    resolution: {integrity: sha512-fHR5tY7u62E8mIx2CC7aMDepQKeuBHpbB5DKsGzP6zp+8s1VngWXiQzcemYvLpFUac8BxNy49Ku+ckFQjFoGpQ==}
     dependencies:
-      '@warp-ds/fonts': 1.1.0
       '@warp-ds/tokenizer': 0.0.2
       '@warp-ds/uno': 1.1.0
-    dev: false
-
-  /@warp-ds/fonts@1.1.0:
-    resolution: {integrity: sha512-kLNZzK3o0rMJApm7/YT3K7rYoFKgH5PyJMTVwv34O4Dx6ikfN7appc4f2DFYkE2XY6gifpD5F2r1ftcJtdW4+w==}
     dev: false
 
   /@warp-ds/icons@1.1.0:


### PR DESCRIPTION
- update @warp-ds/css to 1.1.2 to make full-width link (anchor) styled as Button have centered text (Fixes [WARP-347](https://nmp-jira.atlassian.net/browse/WARP-347))
- update @warp-ds/icons to 1.1.0 to fix translations in svg titles
- default doc site language to English