### PR TITLE
fix: a11y issues for expandable

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@chbphone55/classnames": "^2.0.0",
     "@lingui/core": "^4.3.0",
     "@warp-ds/core": "^1.0.0",
-    "@warp-ds/css": "^1.1.3-next.1",
+    "@warp-ds/css": "^1.2.0",
     "@warp-ds/uno": "^1.1.0",
     "@warp-ds/icons": "1.1.1",
     "react-focus-lock": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@chbphone55/classnames": "^2.0.0",
     "@lingui/core": "^4.3.0",
     "@warp-ds/core": "^1.0.0",
-    "@warp-ds/css": "^1.1.2",
+    "@warp-ds/css": "^1.1.3-next.1",
     "@warp-ds/uno": "^1.1.0",
     "@warp-ds/icons": "1.1.0",
     "react-focus-lock": "^2.5.2",

--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -35,10 +35,10 @@ export function Expandable(props: ExpandableProps) {
 
 	const toggleExpandable = (state) => {
 		setStateExpanded(!state)
-		if (onChange) onChange(!state)
 		setTimeout(() => {
 			setShowChevronUp(!state)
 		}, 200)
+		if (onChange) onChange(!state)
 	}
 
 	return (
@@ -75,18 +75,18 @@ export function Expandable(props: ExpandableProps) {
 									[ccExpandable.chevronNonBox]: !box,
 								})}
 							>
-								{!showChevronUp ? (
+                {showChevronUp ? (
+                  <IconChevronUp16
+                  className={classNames({
+                    [ccExpandable.chevronCollapse]:
+                      !stateExpanded && showChevronUp,
+                  })}
+                />
+								) : (
 									<IconChevronDown16
 										className={classNames({
 											[ccExpandable.chevronExpand]:
 												stateExpanded && !showChevronUp,
-										})}
-									/>
-								) : (
-									<IconChevronUp16
-										className={classNames({
-											[ccExpandable.chevronCollapse]:
-												!stateExpanded && showChevronUp,
 										})}
 									/>
 								)}

--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -67,66 +67,31 @@ export function Expandable(props: ExpandableProps) {
 						) : (
 							title
 						)}
-
-						{/* Discuss which solution to go with:
-            First option:  */}
 						{chevron && (
 							<div
 								className={classNames({
 									[ccExpandable.chevron]: true,
-									[ccExpandable.chevronExpand]: stateExpanded && !showChevronUp,
-									[ccExpandable.chevronCollapse]:
-										!stateExpanded && showChevronUp,
 									[ccExpandable.chevronBox]: box,
 									[ccExpandable.chevronNonBox]: !box,
 								})}
 							>
-								{!showChevronUp ? <IconChevronDown16 /> : <IconChevronUp16 />}
+								{!showChevronUp ? (
+									<IconChevronDown16
+										className={classNames({
+											[ccExpandable.chevronExpand]:
+												stateExpanded && !showChevronUp,
+										})}
+									/>
+								) : (
+									<IconChevronUp16
+										className={classNames({
+											[ccExpandable.chevronCollapse]:
+												!stateExpanded && showChevronUp,
+										})}
+									/>
+								)}
 							</div>
 						)}
-            {/* Pros:
-                We keep the solution in the same div as before. No repetition.
-
-                Cons:
-                The transition isn’t as smooth. 
-                The animation is still there but it animates and then jumps for a split-section.  */}
-
-						{/* Second option:  */}
-						{/* {chevron && (
-              <div
-                className={classNames({
-                  [ccExpandable.chevron]: true,
-                  [ccExpandable.chevronExpand]: stateExpanded && !showChevronUp,
-                  [ccExpandable.chevronCollapse]: !stateExpanded && showChevronUp,
-                  [ccExpandable.chevronBox]: box,
-                  [ccExpandable.chevronNonBox]: !box,
-                })}
-              >
-                {!showChevronUp && (
-                  <IconChevronDown16 />
-                )}
-              </div>
-            )}
-            {chevron && (
-              <div
-                className={classNames({
-                  [ccExpandable.chevron]: true,
-                  [ccExpandable.chevronBox]: box,
-                  [ccExpandable.chevronCollapse]: !stateExpanded && showChevronUp,
-                  [ccExpandable.chevronNonBox]: !box,
-                })}
-              >
-                {showChevronUp && (
-                  <IconChevronUp16 />
-                )}
-              </div>
-            )} */}
-
-            {/* Pros:
-                Gives a smooth transition between the icons
-                Cons: 
-                A lot of repetition
-            */}
 					</div>
 				</button>
 			</UnstyledHeading>

--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -12,6 +12,7 @@ export function Expandable(props: ExpandableProps) {
 	const {
 		children,
 		expanded = false,
+		showChevronUpIcon = false,
 		title = '',
 		info = false,
 		box = false,
@@ -27,7 +28,7 @@ export function Expandable(props: ExpandableProps) {
 	} = props
 
 	const [stateExpanded, setStateExpanded] = React.useState(expanded)
-	const [showChevronUp, setShowChevronUp] = React.useState(false)
+	const [showChevronUp, setShowChevronUp] = React.useState(showChevronUpIcon)
 
 	React.useEffect(() => {
 		setStateExpanded(expanded)

--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -75,16 +75,18 @@ export function Expandable(props: ExpandableProps) {
 									[ccExpandable.chevronNonBox]: !box,
 								})}
 							>
-                {showChevronUp ? (
-                  <IconChevronUp16
-                  className={classNames({
-                    [ccExpandable.chevronCollapse]:
-                      !stateExpanded && showChevronUp,
-                  })}
-                />
+								{showChevronUp ? (
+									<IconChevronUp16
+										className={classNames({
+											[ccExpandable.chevronTransform]: true,
+											[ccExpandable.chevronCollapse]:
+												!stateExpanded && showChevronUp,
+										})}
+									/>
 								) : (
 									<IconChevronDown16
 										className={classNames({
+											[ccExpandable.chevronTransform]: true,
 											[ccExpandable.chevronExpand]:
 												stateExpanded && !showChevronUp,
 										})}

--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -12,7 +12,6 @@ export function Expandable(props: ExpandableProps) {
   const {
     children,
     expanded = false,
-    showChevronUpIcon = false,
     title = '',
     info = false,
     box = false,
@@ -28,7 +27,7 @@ export function Expandable(props: ExpandableProps) {
   } = props
 
   const [stateExpanded, setStateExpanded] = React.useState(expanded)
-  const [showChevronUp, setShowChevronUp] = React.useState(showChevronUpIcon)
+  const [showChevronUp, setShowChevronUp] = React.useState(expanded)
 
   React.useEffect(() => {
     setStateExpanded(expanded)
@@ -36,6 +35,7 @@ export function Expandable(props: ExpandableProps) {
 
   const toggleExpandable = (state) => {
     setStateExpanded(!state)
+    // We need a slight delay for the animation since it has a transition-duration of 150ms:
     setTimeout(() => {
       setShowChevronUp(!state)
     }, 200)

--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -1,7 +1,7 @@
 import { classNames } from '@chbphone55/classnames'
 import {
-	box as ccBox,
-	expandable as ccExpandable,
+  box as ccBox,
+  expandable as ccExpandable,
 } from '@warp-ds/css/component-classes'
 import React from 'react'
 import { ExpandTransition, UnstyledHeading } from '../../_helpers'
@@ -9,122 +9,122 @@ import { ExpandableProps } from './props'
 import { IconChevronDown16, IconChevronUp16 } from '@warp-ds/icons/react'
 
 export function Expandable(props: ExpandableProps) {
-	const {
-		children,
-		expanded = false,
-		showChevronUpIcon = false,
-		title = '',
-		info = false,
-		box = false,
-		bleed = false,
-		buttonClass = '',
-		contentClass = '',
-		className,
-		onChange,
-		chevron = true,
-		animated,
-		headingLevel,
-		...rest
-	} = props
+  const {
+    children,
+    expanded = false,
+    showChevronUpIcon = false,
+    title = '',
+    info = false,
+    box = false,
+    bleed = false,
+    buttonClass = '',
+    contentClass = '',
+    className,
+    onChange,
+    chevron = true,
+    animated,
+    headingLevel,
+    ...rest
+  } = props
 
-	const [stateExpanded, setStateExpanded] = React.useState(expanded)
-	const [showChevronUp, setShowChevronUp] = React.useState(showChevronUpIcon)
+  const [stateExpanded, setStateExpanded] = React.useState(expanded)
+  const [showChevronUp, setShowChevronUp] = React.useState(showChevronUpIcon)
 
-	React.useEffect(() => {
-		setStateExpanded(expanded)
-	}, [expanded])
+  React.useEffect(() => {
+    setStateExpanded(expanded)
+  }, [expanded])
 
-	const toggleExpandable = (state) => {
-		setStateExpanded(!state)
-		setTimeout(() => {
-			setShowChevronUp(!state)
-		}, 200)
-		if (onChange) onChange(!state)
-	}
+  const toggleExpandable = (state) => {
+    setStateExpanded(!state)
+    setTimeout(() => {
+      setShowChevronUp(!state)
+    }, 200)
+    if (onChange) onChange(!state)
+  }
 
-	return (
-		<div
-			{...rest}
-			className={classNames(className, {
-				[ccExpandable.expandable]: true,
-				[ccExpandable.expandableBox]: box,
-				[ccExpandable.expandableBleed]: bleed,
-			})}
-		>
-			<UnstyledHeading level={headingLevel}>
-				<button
-					type='button'
-					aria-expanded={stateExpanded}
-					className={classNames({
-						[buttonClass || '']: true,
-						[ccExpandable.button]: true,
-						[ccExpandable.buttonBox]: box,
-					})}
-					onClick={() => toggleExpandable(stateExpanded)}
-				>
-					<div className={ccExpandable.title}>
-						{typeof title === 'string' ? (
-							<span className={ccExpandable.titleType}>{title}</span>
-						) : (
-							title
-						)}
-						{chevron && (
-							<div
-								className={classNames({
-									[ccExpandable.chevron]: true,
-									[ccExpandable.chevronBox]: box,
-									[ccExpandable.chevronNonBox]: !box,
-								})}
-							>
-								{showChevronUp ? (
-									<IconChevronUp16
-										className={classNames({
-											[ccExpandable.chevronTransform]: true,
-											[ccExpandable.chevronCollapse]:
-												!stateExpanded && showChevronUp,
-										})}
-									/>
-								) : (
-									<IconChevronDown16
-										className={classNames({
-											[ccExpandable.chevronTransform]: true,
-											[ccExpandable.chevronExpand]:
-												stateExpanded && !showChevronUp,
-										})}
-									/>
-								)}
-							</div>
-						)}
-					</div>
-				</button>
-			</UnstyledHeading>
-			<ExpansionBehaviour animated={animated} stateExpanded={stateExpanded}>
-				<div
-					className={classNames({
-						[contentClass || '']: true,
-						[ccBox.box]: box,
-						[ccExpandable.paddingTop]: box && title,
-					})}
-				>
-					{children}
-				</div>
-			</ExpansionBehaviour>
-		</div>
-	)
+  return (
+    <div
+      {...rest}
+      className={classNames(className, {
+        [ccExpandable.expandable]: true,
+        [ccExpandable.expandableBox]: box,
+        [ccExpandable.expandableBleed]: bleed,
+      })}
+    >
+      <UnstyledHeading level={headingLevel}>
+        <button
+          type='button'
+          aria-expanded={stateExpanded}
+          className={classNames({
+            [buttonClass || '']: true,
+            [ccExpandable.button]: true,
+            [ccExpandable.buttonBox]: box,
+          })}
+          onClick={() => toggleExpandable(stateExpanded)}
+        >
+          <div className={ccExpandable.title}>
+            {typeof title === 'string' ? (
+              <span className={ccExpandable.titleType}>{title}</span>
+            ) : (
+              title
+            )}
+            {chevron && (
+              <div
+                className={classNames({
+                  [ccExpandable.chevron]: true,
+                  [ccExpandable.chevronBox]: box,
+                  [ccExpandable.chevronNonBox]: !box,
+                })}
+              >
+                {showChevronUp ? (
+                  <IconChevronUp16
+                    className={classNames({
+                      [ccExpandable.chevronTransform]: true,
+                      [ccExpandable.chevronCollapse]:
+                        !stateExpanded && showChevronUp,
+                    })}
+                  />
+                ) : (
+                  <IconChevronDown16
+                    className={classNames({
+                      [ccExpandable.chevronTransform]: true,
+                      [ccExpandable.chevronExpand]:
+                        stateExpanded && !showChevronUp,
+                    })}
+                  />
+                )}
+              </div>
+            )}
+          </div>
+        </button>
+      </UnstyledHeading>
+      <ExpansionBehaviour animated={animated} stateExpanded={stateExpanded}>
+        <div
+          className={classNames({
+            [contentClass || '']: true,
+            [ccBox.box]: box,
+            [ccExpandable.paddingTop]: box && title,
+          })}
+        >
+          {children}
+        </div>
+      </ExpansionBehaviour>
+    </div>
+  )
 }
 
 function ExpansionBehaviour({ animated, stateExpanded, children }) {
-	return animated ? (
-		<ExpandTransition show={stateExpanded}>{children}</ExpandTransition>
-	) : (
-		<div
-			className={classNames({
-				[ccExpandable.expansion]: true,
-				[ccExpandable.expansionNotExpanded]: !stateExpanded,
-			})}
-			aria-hidden={!stateExpanded ? true : undefined}
-		>
-			{children}
-		</div>
-	)
+  return animated ? (
+    <ExpandTransition show={stateExpanded}>{children}</ExpandTransition>
+  ) : (
+    <div
+      className={classNames({
+        [ccExpandable.expansion]: true,
+        [ccExpandable.expansionNotExpanded]: !stateExpanded,
+      })}
+      aria-hidden={!stateExpanded ? true : undefined}
+    >
+      {children}
+    </div>
+  )
 }

--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -1,110 +1,162 @@
-import { classNames } from "@chbphone55/classnames";
+import { classNames } from '@chbphone55/classnames'
 import {
-  box as ccBox,
-  expandable as ccExpandable,
-} from "@warp-ds/css/component-classes";
-import React from "react";
-import { ExpandTransition, UnstyledHeading } from "../../_helpers";
-import { ExpandableProps } from "./props";
-import { IconChevronDown16 } from "@warp-ds/icons/react";
+	box as ccBox,
+	expandable as ccExpandable,
+} from '@warp-ds/css/component-classes'
+import React from 'react'
+import { ExpandTransition, UnstyledHeading } from '../../_helpers'
+import { ExpandableProps } from './props'
+import { IconChevronDown16, IconChevronUp16 } from '@warp-ds/icons/react'
 
 export function Expandable(props: ExpandableProps) {
-  const {
-    children,
-    expanded = false,
-    title = "",
-    info = false,
-    box = false,
-    bleed = false,
-    buttonClass = "",
-    contentClass = "",
-    className,
-    onChange,
-    chevron = true,
-    animated,
-    headingLevel,
-    ...rest
-  } = props;
+	const {
+		children,
+		expanded = false,
+		title = '',
+		info = false,
+		box = false,
+		bleed = false,
+		buttonClass = '',
+		contentClass = '',
+		className,
+		onChange,
+		chevron = true,
+		animated,
+		headingLevel,
+		...rest
+	} = props
 
-  const [stateExpanded, setStateExpanded] = React.useState(expanded);
+	const [stateExpanded, setStateExpanded] = React.useState(expanded)
+	const [showChevronUp, setShowChevronUp] = React.useState(false)
 
-  React.useEffect(() => {
-    setStateExpanded(expanded);
-  }, [expanded]);
+	React.useEffect(() => {
+		setStateExpanded(expanded)
+	}, [expanded])
 
-  const toggleExpandable = (state) => {
-    setStateExpanded(!state);
-    if (onChange) onChange(!state);
-  };
+	const toggleExpandable = (state) => {
+		setStateExpanded(!state)
+		if (onChange) onChange(!state)
+		setTimeout(() => {
+			setShowChevronUp(!state)
+		}, 200)
+	}
 
-  return (
-    <div
-      {...rest}
-      className={classNames(className, {
-        [ccExpandable.expandable]: true,
-        [ccExpandable.expandableBox]: box,
-        [ccExpandable.expandableBleed]: bleed,
-      })}
-    >
-      <UnstyledHeading level={headingLevel}>
-        <button
-          type="button"
-          aria-expanded={stateExpanded}
-          className={classNames({
-            [buttonClass || ""]: true,
-            [ccExpandable.button]: true,
-            [ccExpandable.buttonBox]: box,
-          })}
-          onClick={() => toggleExpandable(stateExpanded)}
-        >
-          <div className={ccExpandable.title}>
-            {typeof title === "string" ? (
-              <span className={ccExpandable.titleType}>{title}</span>
-            ) : (
-              title
+	return (
+		<div
+			{...rest}
+			className={classNames(className, {
+				[ccExpandable.expandable]: true,
+				[ccExpandable.expandableBox]: box,
+				[ccExpandable.expandableBleed]: bleed,
+			})}
+		>
+			<UnstyledHeading level={headingLevel}>
+				<button
+					type='button'
+					aria-expanded={stateExpanded}
+					className={classNames({
+						[buttonClass || '']: true,
+						[ccExpandable.button]: true,
+						[ccExpandable.buttonBox]: box,
+					})}
+					onClick={() => toggleExpandable(stateExpanded)}
+				>
+					<div className={ccExpandable.title}>
+						{typeof title === 'string' ? (
+							<span className={ccExpandable.titleType}>{title}</span>
+						) : (
+							title
+						)}
+
+						{/* Discuss which solution to go with:
+            First option:  */}
+						{chevron && (
+							<div
+								className={classNames({
+									[ccExpandable.chevron]: true,
+									[ccExpandable.chevronExpand]: stateExpanded && !showChevronUp,
+									[ccExpandable.chevronCollapse]:
+										!stateExpanded && showChevronUp,
+									[ccExpandable.chevronBox]: box,
+									[ccExpandable.chevronNonBox]: !box,
+								})}
+							>
+								{!showChevronUp ? <IconChevronDown16 /> : <IconChevronUp16 />}
+							</div>
+						)}
+            {/* Pros:
+                We keep the solution in the same div as before. No repetition.
+
+                Cons:
+                The transition isn’t as smooth. 
+                The animation is still there but it animates and then jumps for a split-section.  */}
+
+						{/* Second option:  */}
+						{/* {chevron && (
+              <div
+                className={classNames({
+                  [ccExpandable.chevron]: true,
+                  [ccExpandable.chevronExpand]: stateExpanded && !showChevronUp,
+                  [ccExpandable.chevronCollapse]: !stateExpanded && showChevronUp,
+                  [ccExpandable.chevronBox]: box,
+                  [ccExpandable.chevronNonBox]: !box,
+                })}
+              >
+                {!showChevronUp && (
+                  <IconChevronDown16 />
+                )}
+              </div>
             )}
             {chevron && (
               <div
                 className={classNames({
                   [ccExpandable.chevron]: true,
-                  [ccExpandable.chevronExpanded]: stateExpanded,
                   [ccExpandable.chevronBox]: box,
+                  [ccExpandable.chevronCollapse]: !stateExpanded && showChevronUp,
                   [ccExpandable.chevronNonBox]: !box,
                 })}
               >
-                <IconChevronDown16 />
+                {showChevronUp && (
+                  <IconChevronUp16 />
+                )}
               </div>
-            )}
-          </div>
-        </button>
-      </UnstyledHeading>
-      <ExpansionBehaviour animated={animated} stateExpanded={stateExpanded}>
-        <div
-          className={classNames({
-            [contentClass || ""]: true,
-            [ccBox.box]: box,
-            [ccExpandable.paddingTop]: box && title,
-          })}
-        >
-          {children}
-        </div>
-      </ExpansionBehaviour>
-    </div>
-  );
+            )} */}
+
+            {/* Pros:
+                Gives a smooth transition between the icons
+                Cons: 
+                A lot of repetition
+            */}
+					</div>
+				</button>
+			</UnstyledHeading>
+			<ExpansionBehaviour animated={animated} stateExpanded={stateExpanded}>
+				<div
+					className={classNames({
+						[contentClass || '']: true,
+						[ccBox.box]: box,
+						[ccExpandable.paddingTop]: box && title,
+					})}
+				>
+					{children}
+				</div>
+			</ExpansionBehaviour>
+		</div>
+	)
 }
 
 function ExpansionBehaviour({ animated, stateExpanded, children }) {
-  return animated ? (
-    <ExpandTransition show={stateExpanded}>{children}</ExpandTransition>
-  ) : (
-    <div
-      className={classNames({
-        [ccExpandable.expansion]: true,
-        [ccExpandable.expansionNotExpanded]: !stateExpanded,
-      })}
-      aria-hidden={!stateExpanded ? true : undefined}
-    >
-      {children}
-    </div>
-  );
+	return animated ? (
+		<ExpandTransition show={stateExpanded}>{children}</ExpandTransition>
+	) : (
+		<div
+			className={classNames({
+				[ccExpandable.expansion]: true,
+				[ccExpandable.expansionNotExpanded]: !stateExpanded,
+			})}
+			aria-hidden={!stateExpanded ? true : undefined}
+		>
+			{children}
+		</div>
+	)
 }

--- a/packages/expandable/src/props.tsx
+++ b/packages/expandable/src/props.tsx
@@ -33,6 +33,12 @@ export type ExpandableProps = {
   expanded?: boolean;
 
   /**
+   * The state of the chevron-up icon, if set to true, chevron up should be displayed, if set to false then chevron-down icon should be displayed.
+   * @default false
+   */
+  showChevronUpIcon?: boolean;
+
+  /**
    * Event function to be called any time the component is expanded or closed. Function will be passed a boolean with a value of true if the component is now expanded or false if it is now closed.
    */
   onChange?: (state: boolean) => void;

--- a/packages/expandable/src/props.tsx
+++ b/packages/expandable/src/props.tsx
@@ -33,12 +33,6 @@ export type ExpandableProps = {
   expanded?: boolean;
 
   /**
-   * The state of the chevron-up icon, if set to true, chevron up should be displayed, if set to false then chevron-down icon should be displayed.
-   * @default false
-   */
-  showChevronUpIcon?: boolean;
-
-  /**
    * Event function to be called any time the component is expanded or closed. Function will be passed a boolean with a value of true if the component is now expanded or false if it is now closed.
    */
   onChange?: (state: boolean) => void;

--- a/packages/expandable/stories/Expandable.stories.tsx
+++ b/packages/expandable/stories/Expandable.stories.tsx
@@ -7,34 +7,34 @@ export default metadata;
 
 export const Default = () => (
   <Expandable title="This is a title">
-    <h1>I am expandable</h1>
+    <h2>I am expandable</h2>
   </Expandable>
 );
 
 export const Box = () => (
   <Expandable title="This is a title" box>
-    <h1>I am expandable</h1>
+    <h2>I am expandable</h2>
   </Expandable>
 );
 
 export const BoxWithCustomIcon = () => (
   <Expandable
     title={
-      <div className="flex flex-row items-center">
+      <div className="flex flex-row items-center" aria-label="This is a title with an icon, ">
+        <p className="mr-8 mb-0">This is a title with an icon</p>
         <IconBag16 />
-        <p className="ml-8 mb-0">This is a title with an icon</p>
       </div>
     }
     box
     info
   >
-    <h1>I am expandable</h1>
+    <h2>I am expandable</h2>
   </Expandable>
 );
 
 export const InfoBox = () => (
   <Expandable title="This is a title" box info>
-    <h1>I am expandable</h1>
+    <h2>I am expandable</h2>
   </Expandable>
 );
 
@@ -57,7 +57,7 @@ export const NoChevron = () => {
       chevron={false}
       onChange={setOpen}
     >
-      <h1>I am expandable</h1>
+      <h2>I am expandable</h2>
     </Expandable>
   );
 };
@@ -65,7 +65,7 @@ export const NoChevron = () => {
 export const Animated = () => {
   return (
     <Expandable title="Animated box" box info animated>
-      <h1>I am expandable</h1>
+      <h2>I am expandable</h2>
     </Expandable>
   );
 };
@@ -73,7 +73,7 @@ export const Animated = () => {
 export const AnimatedExpanded = () => {
   return (
     <Expandable title="Animated box" expanded box info animated>
-      <h1>I am expandable</h1>
+      <h2>I am expandable</h2>
     </Expandable>
   );
 };
@@ -81,7 +81,7 @@ export const AnimatedExpanded = () => {
 export const Heading = () => {
   return (
     <Expandable title="I'm also a heading" headingLevel={1}>
-      <h1>I am expandable</h1>
+      <h2>I am expandable</h2>
     </Expandable>
   );
 };

--- a/packages/expandable/stories/Expandable.stories.tsx
+++ b/packages/expandable/stories/Expandable.stories.tsx
@@ -20,8 +20,9 @@ export const Box = () => (
 export const BoxWithCustomIcon = () => (
   <Expandable
     title={
-      <div className="flex flex-row items-center" aria-label="This is a title with an icon, ">
+      <div className="flex flex-row items-center">
         <p className="mr-8 mb-0">This is a title with an icon</p>
+        <span className="sr-only">,</span>
         <IconBag16 />
       </div>
     }

--- a/packages/expandable/stories/Expandable.stories.tsx
+++ b/packages/expandable/stories/Expandable.stories.tsx
@@ -79,7 +79,6 @@ export const AnimatedExpanded = () => {
       box
       info
       animated
-      showChevronUpIcon
     >
       <h2>I am expandable</h2>
     </Expandable>

--- a/packages/expandable/stories/Expandable.stories.tsx
+++ b/packages/expandable/stories/Expandable.stories.tsx
@@ -1,28 +1,28 @@
-import { IconBag16 } from '@warp-ds/icons/react';
-import * as React from 'react';
-import { Expandable } from '../src';
+import { IconBag16 } from '@warp-ds/icons/react'
+import * as React from 'react'
+import { Expandable } from '../src'
 
-const metadata = { title: 'Layout/Expandable' };
-export default metadata;
+const metadata = { title: 'Layout/Expandable' }
+export default metadata
 
 export const Default = () => (
-  <Expandable title="This is a title">
+  <Expandable title='This is a title'>
     <h2>I am expandable</h2>
   </Expandable>
-);
+)
 
 export const Box = () => (
-  <Expandable title="This is a title" box>
+  <Expandable title='This is a title' box>
     <h2>I am expandable</h2>
   </Expandable>
-);
+)
 
 export const BoxWithCustomIcon = () => (
   <Expandable
     title={
-      <div className="flex flex-row items-center">
-        <p className="mr-8 mb-0">This is a title with an icon</p>
-        <span className="sr-only">,</span>
+      <div className='flex flex-row items-center'>
+        <p className='mr-8 mb-0'>This is a title with an icon</p>
+        <span className='sr-only'>,</span>
         <IconBag16 />
       </div>
     }
@@ -31,25 +31,25 @@ export const BoxWithCustomIcon = () => (
   >
     <h2>I am expandable</h2>
   </Expandable>
-);
+)
 
 export const InfoBox = () => (
-  <Expandable title="This is a title" box info>
+  <Expandable title='This is a title' box info>
     <h2>I am expandable</h2>
   </Expandable>
-);
+)
 
 export const Controlled = () => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = React.useState(false)
   return (
     <Expandable title={open ? 'Open' : 'Closed'} box info onChange={setOpen}>
       <h1>I am expandable</h1>
     </Expandable>
-  );
-};
+  )
+}
 
 export const NoChevron = () => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = React.useState(false)
   return (
     <Expandable
       title={open ? 'Open' : 'Closed'}
@@ -60,29 +60,36 @@ export const NoChevron = () => {
     >
       <h2>I am expandable</h2>
     </Expandable>
-  );
-};
+  )
+}
 
 export const Animated = () => {
   return (
-    <Expandable title="Animated box" box info animated>
+    <Expandable title='Animated box' box info animated>
       <h2>I am expandable</h2>
     </Expandable>
-  );
-};
+  )
+}
 
 export const AnimatedExpanded = () => {
   return (
-    <Expandable title="Animated box" expanded box info animated showChevronUpIcon>
+    <Expandable
+      title='Animated box'
+      expanded
+      box
+      info
+      animated
+      showChevronUpIcon
+    >
       <h2>I am expandable</h2>
     </Expandable>
-  );
-};
+  )
+}
 
 export const Heading = () => {
   return (
     <Expandable title="I'm also a heading" headingLevel={1}>
       <h2>I am expandable</h2>
     </Expandable>
-  );
-};
+  )
+}

--- a/packages/expandable/stories/Expandable.stories.tsx
+++ b/packages/expandable/stories/Expandable.stories.tsx
@@ -73,7 +73,7 @@ export const Animated = () => {
 
 export const AnimatedExpanded = () => {
   return (
-    <Expandable title="Animated box" expanded box info animated>
+    <Expandable title="Animated box" expanded box info animated showChevronUpIcon>
       <h2>I am expandable</h2>
     </Expandable>
   );

--- a/packages/expandable/stories/Expandable.stories.tsx
+++ b/packages/expandable/stories/Expandable.stories.tsx
@@ -87,7 +87,7 @@ export const AnimatedExpanded = () => {
 
 export const Heading = () => {
   return (
-    <Expandable title="I'm also a heading" headingLevel={1}>
+    <Expandable title="I'm also a heading" headingLevel={2}>
       <h2>I am expandable</h2>
     </Expandable>
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: ^1.0.0
     version: 1.0.0
   '@warp-ds/css':
-    specifier: ^1.1.3-next.1
-    version: 1.1.3-next.1
+    specifier: ^1.2.0
+    version: 1.2.0
   '@warp-ds/icons':
     specifier: 1.1.1
     version: 1.1.1
@@ -5820,8 +5820,8 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/css@1.1.3-next.1:
-    resolution: {integrity: sha512-BW44z20zC4Wb3ggHAS+ABDtcL5ZpvxWn8T8YC6IeFHYaaNkIMo0T+HuuaipXPUxzq1GAt5PEj1PrD7TqlupPeg==}
+  /@warp-ds/css@1.2.0:
+    resolution: {integrity: sha512-IcEVL9i1I7v8gkuQ7yVDx25sqyO/FbR2q87h0SM+o/8oTy0hLWCkqOGkEATYt+Z7aV3Yfw8Qp38tQlQnkhhicw==}
     dependencies:
       '@warp-ds/tokenizer': 0.0.2
       '@warp-ds/uno': 1.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: ^1.0.0
     version: 1.0.0
   '@warp-ds/css':
-    specifier: ^1.1.2
-    version: 1.1.2
+    specifier: ^1.1.3-next.1
+    version: 1.1.3-next.1
   '@warp-ds/icons':
     specifier: 1.1.0
     version: 1.1.0
@@ -5818,8 +5818,8 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/css@1.1.2:
-    resolution: {integrity: sha512-fHR5tY7u62E8mIx2CC7aMDepQKeuBHpbB5DKsGzP6zp+8s1VngWXiQzcemYvLpFUac8BxNy49Ku+ckFQjFoGpQ==}
+  /@warp-ds/css@1.1.3-next.1:
+    resolution: {integrity: sha512-BW44z20zC4Wb3ggHAS+ABDtcL5ZpvxWn8T8YC6IeFHYaaNkIMo0T+HuuaipXPUxzq1GAt5PEj1PrD7TqlupPeg==}
     dependencies:
       '@warp-ds/tokenizer': 0.0.2
       '@warp-ds/uno': 1.1.0


### PR DESCRIPTION
Fix a11y issues for expandable component in [WARP-326](https://nmp-jira.atlassian.net/browse/WARP-326) :

- Switch between ChevronDownIcon and ChevronUpIcon depending on if expanded is set to true or not. This will set the correct svg-title for the icons. 
- Move Icon in the "Box With Custom Icon" story to after the text.
- Add a comma with sr-only to add a pause between the text and the svg-title for screen readers.
- Change text "I am expandable" to a `<h2>` instead of a `<h1>`

