### PR TITLE
fix: add a11y attributes for to define steps in more accessible way

### DIFF
--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -45,6 +45,10 @@ const config: LinguiConfig = {
       include: ['packages/toggle/src/**/*.{ts,tsx}'],
       path: 'packages/toggle/src/locales/{locale}/messages',
     },
+    {
+      include: ['packages/steps/src/**/*.{ts,tsx}'],
+      path: 'packages/steps/src/locales/{locale}/messages',
+    },
   ],
   compileNamespace: 'es',
 };

--- a/packages/steps/src/component.tsx
+++ b/packages/steps/src/component.tsx
@@ -20,14 +20,14 @@ export function Steps({horizontal, right, className, children}: StepsProps) {
         right: right,
       }}
     >
-      <div
+      <ul
         className={classNames(className, {
           [ccSteps.steps]: true,
           [ccSteps.stepsHorizontal]: horizontal,
         })}
       >
         {children}
-      </div>
+      </ul>
     </StepsContext.Provider>
   );
 }

--- a/packages/steps/src/locales/en/messages.mjs
+++ b/packages/steps/src/locales/en/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"steps.aria.emptyCircle\":\"Empty circle\",\"steps.aria.active\":\"Step indicator active circle\",\"steps.aria.completed\":\"Step indicator completed circle\"}");

--- a/packages/steps/src/locales/en/messages.po
+++ b/packages/steps/src/locales/en/messages.po
@@ -1,0 +1,14 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-10-24 09:48+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: en\n"
+
+#. Empty circle
+#. js-lingui-explicit-id
+#: packages/steps/src/step.tsx:79
+msgid "steps.aria.emptyCircle"
+msgstr "Empty circle"

--- a/packages/steps/src/locales/en/messages.po
+++ b/packages/steps/src/locales/en/messages.po
@@ -6,9 +6,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. Empty circle
 #. js-lingui-explicit-id
-#: packages/steps/src/step.tsx:79
+#: packages/steps/src/step.tsx:25
 msgid "steps.aria.emptyCircle"
 msgstr "Empty circle"
+
+#. Active circle
+#. js-lingui-explicit-id
+#: packages/steps/src/step.tsx:18
+msgid "steps.aria.active"
+msgstr "Step indicator active circle"
+
+#. Completed circle
+#. js-lingui-explicit-id
+#: packages/steps/src/step.tsx:11
+msgid "steps.aria.completed"
+msgstr "Step indicator completed circle"

--- a/packages/steps/src/locales/fi/messages.po
+++ b/packages/steps/src/locales/fi/messages.po
@@ -6,9 +6,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: fi\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. Empty circle
 #. js-lingui-explicit-id
-#: packages/steps/src/step.tsx:79
+#: packages/steps/src/step.tsx:25
 msgid "steps.aria.emptyCircle"
+msgstr ""
+
+#. Active circle
+#. js-lingui-explicit-id
+#: packages/steps/src/step.tsx:18
+msgid "steps.aria.active"
+msgstr ""
+
+#. Completed circle
+#. js-lingui-explicit-id
+#: packages/steps/src/step.tsx:11
+msgid "steps.aria.completed"
 msgstr ""

--- a/packages/steps/src/locales/fi/messages.po
+++ b/packages/steps/src/locales/fi/messages.po
@@ -1,0 +1,14 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-10-24 09:48+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: fi\n"
+
+#. Empty circle
+#. js-lingui-explicit-id
+#: packages/steps/src/step.tsx:79
+msgid "steps.aria.emptyCircle"
+msgstr ""

--- a/packages/steps/src/locales/nb/messages.po
+++ b/packages/steps/src/locales/nb/messages.po
@@ -1,0 +1,14 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-10-24 09:48+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: nb\n"
+
+#. Empty circle
+#. js-lingui-explicit-id
+#: packages/steps/src/step.tsx:79
+msgid "steps.aria.emptyCircle"
+msgstr ""

--- a/packages/steps/src/locales/nb/messages.po
+++ b/packages/steps/src/locales/nb/messages.po
@@ -6,9 +6,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: nb\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. Empty circle
 #. js-lingui-explicit-id
-#: packages/steps/src/step.tsx:79
+#: packages/steps/src/step.tsx:25
 msgid "steps.aria.emptyCircle"
+msgstr ""
+
+#. Active circle
+#. js-lingui-explicit-id
+#: packages/steps/src/step.tsx:18
+msgid "steps.aria.active"
+msgstr ""
+
+#. Completed circle
+#. js-lingui-explicit-id
+#: packages/steps/src/step.tsx:11
+msgid "steps.aria.completed"
 msgstr ""

--- a/packages/steps/src/step.tsx
+++ b/packages/steps/src/step.tsx
@@ -4,6 +4,7 @@ import { step as ccStep } from "@warp-ds/css/component-classes";
 import { useContext } from "react";
 import { StepsContext } from "./component";
 import { IconCheck16 } from "@warp-ds/icons/react";
+import { i18n } from '@lingui/core';
 
 export interface StepProps {
   /**
@@ -72,7 +73,15 @@ export function Step({ active, completed, children }: StepProps) {
     <li className={stepClasses}>
       {!vertical && <div className={stepLineHorizontalClasses} />}
       <div className={stepDotClasses}
-      {...(!active && !completed && { role: 'img', 'aria-label': 'empty circle'})}
+      {...(!active && !completed && { 
+        role: 'img', 
+      'aria-label': i18n._(
+        /*i18n*/ {
+          id: "steps.aria.emptyCircle",
+          message: "Empty circle",
+          comment: "Empty circle",
+        }
+      )})}
       {...(active && { 'aria-current': 'step'})}>{completed && <IconCheck16 />}</div>
       <div className={stepLineClasses} />
       <div className={stepContentClasses}>{children}</div>

--- a/packages/steps/src/step.tsx
+++ b/packages/steps/src/step.tsx
@@ -69,11 +69,13 @@ export function Step({ active, completed, children }: StepProps) {
   });
 
   return (
-    <div className={stepClasses}>
+    <li className={stepClasses}>
       {!vertical && <div className={stepLineHorizontalClasses} />}
-      <div className={stepDotClasses}>{completed && <IconCheck16 />}</div>
+      <div className={stepDotClasses}
+      {...(!active && !completed && { role: 'img', 'aria-label': 'empty circle'})}
+      {...(active && { 'aria-current': 'step'})}>{completed && <IconCheck16 />}</div>
       <div className={stepLineClasses} />
       <div className={stepContentClasses}>{children}</div>
-    </div>
+    </li>
   );
 }

--- a/packages/steps/src/step.tsx
+++ b/packages/steps/src/step.tsx
@@ -6,6 +6,34 @@ import { StepsContext } from "./component";
 import { IconCheck16 } from "@warp-ds/icons/react";
 import { i18n } from '@lingui/core';
 
+const availableAriaLabels = {
+  completed: i18n._(
+    /*i18n*/ {
+      id: "steps.aria.completed",
+      message: "Step indicator completed circle",
+      comment: "Completed circle",
+    }
+  ),
+  active: i18n._(
+    /*i18n*/ {
+      id: "steps.aria.active",
+      message: "Step indicator active circle",
+      comment: "Active circle",
+    }
+  ),
+  default: i18n._(
+    /*i18n*/ {
+      id: "steps.aria.emptyCircle",
+      message: "Empty circle",
+      comment: "Empty circle",
+    }
+  )
+}
+
+const getAriaLabel = (props: StepProps) => {
+  const ariaLabel = Object.keys(availableAriaLabels).find(a => props[a]);
+  return ariaLabel ? availableAriaLabels[ariaLabel] : availableAriaLabels.default;
+}
 export interface StepProps {
   /**
    * Step is active
@@ -25,7 +53,8 @@ export interface StepProps {
   children: JSX.Element | JSX.Element[];
 }
 
-export function Step({ active, completed, children }: StepProps) {
+export function Step(props: StepProps) {
+  const { active, completed, children } = props;
   const StepsProps = useContext(StepsContext);
   const vertical = !StepsProps.horizontal;
   const left = !StepsProps.right;
@@ -72,17 +101,9 @@ export function Step({ active, completed, children }: StepProps) {
   return (
     <li className={stepClasses}>
       {!vertical && <div className={stepLineHorizontalClasses} />}
-      <div className={stepDotClasses}
-      {...(!active && !completed && { 
-        role: 'img', 
-      'aria-label': i18n._(
-        /*i18n*/ {
-          id: "steps.aria.emptyCircle",
-          message: "Empty circle",
-          comment: "Empty circle",
-        }
-      )})}
-      {...(active && { 'aria-current': 'step'})}>{completed && <IconCheck16 />}</div>
+      <div className={stepDotClasses} role='img'
+      aria-label={getAriaLabel(props)}
+       {...(active && { 'aria-current': 'step'})}>{completed && <IconCheck16 />}</div>
       <div className={stepLineClasses} />
       <div className={stepContentClasses}>{children}</div>
     </li>


### PR DESCRIPTION
Background: https://nmp-jira.atlassian.net/jira/software/projects/WARP/boards/15?label=web&selectedIssue=WARP-329

- [x] Added role=img and aria-label on the divs that renders the circles (instead of alt text)
- [x] added list markup to communicate the total number of steps to the screen reader
- [x] Added aria-current=step to indicate current step

<img width="1296" alt="image" src="https://github.com/warp-ds/react/assets/37986637/1761c642-55db-420c-a7a5-af4bc83bb651">
