### PR TITLE
fix(combobox): don't open on modifier key press and fix aria-expanded

### DIFF
--- a/packages/combobox/src/component.tsx
+++ b/packages/combobox/src/component.tsx
@@ -116,6 +116,8 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
           navigationOption,
           currentOptions,
         });
+      } else if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
+        return;
       }
 
       // Other keys

--- a/packages/combobox/src/component.tsx
+++ b/packages/combobox/src/component.tsx
@@ -200,7 +200,7 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
       'aria-label': props['aria-label'],
       'aria-labelledby': props['aria-labelledby'],
       'aria-autocomplete': 'list',
-      'aria-expanded': !!navigationOption?.id,
+      'aria-expanded': isOpen && currentOptions.length !== 0,
       'aria-activedescendant': isOpen ? navigationOption?.id : undefined,
       'aria-controls': listboxId,
       onChange: function (e: ChangeEvent<HTMLInputElement>) {


### PR DESCRIPTION
Fixes [WARP-333](https://nmp-jira.atlassian.net/browse/WARP-333)


- notify assistive technologies when the combobox is expanded
- don't open the list of options when a modifier key is pressed