### PR TITLE
chore: don't track _helpers for new translations

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -8,11 +8,6 @@ preserve_hierarchy: true
 files:
       [
             {
-                  "source": "/packages/_helpers/locales/en/messages.po",
-                  "dest": "/react/**/%original_file_name%",
-                  "translation": "/packages/_helpers/locales/%two_letters_code%/messages.po",
-            },
-            {
                   "source": "/packages/breadcrumbs/src/locales/en/messages.po",
                   "dest": "/react/**/%original_file_name%",
                   "translation": "/packages/breadcrumbs/src/locales/%two_letters_code%/messages.po",

--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -6,10 +6,6 @@ const config: LinguiConfig = {
   sourceLocale: 'en',
   catalogs: [
     {
-      include: ['packages/_helpers/**/*.{ts,tsx}'],
-      path: 'packages/_helpers/locales/{locale}/messages',
-    },
-    {
       include: ['packages/breadcrumbs/src/**/*.{ts,tsx}'],
       path: 'packages/breadcrumbs/src/locales/{locale}/messages',
     },


### PR DESCRIPTION
Together with changes from https://github.com/warp-ds/react/pull/154 `/_helpers` need to be removed from crowdin.yml and lingui.config.ts.