### PR TITLE
fix(combobox): open dropdown also on space key press

### DIFF
--- a/packages/combobox/src/component.tsx
+++ b/packages/combobox/src/component.tsx
@@ -108,7 +108,9 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
 
       const ignoreList = ['ArrowDown', 'ArrowLeft', 'ArrowUp', 'ArrowRight'];
 
-      if (isNavigationKey && !isOpen) {
+      if ((e.code === 'Space' || isNavigationKey) && !isOpen) {
+        // Only show dropdown, don't trigger onChange()
+        e.preventDefault();
         return setOpen(true);
       } else if (isNavigationKey && isOpen) {
         findAndSetActiveOption(e, {


### PR DESCRIPTION
Fixes [WARP-333](https://nmp-jira.atlassian.net/browse/WARP-333)

This makes Combobox dropdown open on 'Space' key press, like in the case of the Select component. This was the suggestion from the a11y team. The proper solution should be to open the dropdown on Ctrl+Option+Space combination press. However VoiceOver doesn't detect this key combination for some reason, so having a the dropdown to open on `Space` key press felt like a good enough solution for now.