### PR TITLE
fix(textfield): render prefix before input

### DIFF
--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -34,10 +34,10 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     const helpId = helpText ? `${id}__hint` : undefined;
     const isInvalid = invalid || error;
 
-    const hasSuffix = React.Children.toArray(children).some(
+    const suffix = React.Children.toArray(children).find(
       (child) => React.isValidElement(child) && child.props.suffix,
     );
-    const hasPrefix = React.Children.toArray(children).some(
+    const prefix = React.Children.toArray(children).find(
       (child) => React.isValidElement(child) && child.props.prefix,
     );
 
@@ -66,6 +66,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
             </label>
           )}
           <div className={ccInput.wrapper}>
+            {prefix}
             <input
             className={classNames({
               [ccInput.default]: true,
@@ -73,8 +74,8 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
               [ccInput.disabled]: disabled,
               [ccInput.readOnly]: readOnly,
               [ccInput.placeholder]: !!props.placeholder,
-              [ccInput.suffix]: hasSuffix,
-              [ccInput.prefix]: hasPrefix,    
+              [ccInput.suffix]: !!suffix,
+              [ccInput.prefix]: !!prefix,    
             })}
               {...rest}
               aria-describedby={helpId}
@@ -86,7 +87,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
               ref={ref}
               type={type}
             />
-            {children}
+            {suffix}
           </div>
 
           {helpText && (


### PR DESCRIPTION
Fixes [WARP-337](https://nmp-jira.atlassian.net/browse/WARP-337)

The prefix should be announced before the input, and suffix - after the input.
<img width="201" alt="Exemplary input with prefix and suffix" src="https://github.com/warp-ds/react/assets/41303231/10f1479f-7677-4f9b-bb58-03bb0c5fff89">
Inspected input with prefix and suffix button with correct semantic order
<img width="235" alt="Inspected input with prefix and suffix with correct semantic order" src="https://github.com/warp-ds/react/assets/41303231/2ec2ee0a-7441-4c7a-856e-c553f2561ca8">
