### PR TITLE
docs(affix): add missing aria-labels to Affixes that render as buttons

### DIFF
--- a/packages/combobox/stories/Combobox.stories.tsx
+++ b/packages/combobox/stories/Combobox.stories.tsx
@@ -266,7 +266,7 @@ export const WithAffix = () => {
           { value: 'Pineapple', label: '🍍 Pineapple' },
         ]}
       >
-        <Affix suffix clear onClick={() => setValue('')} />
+        <Affix suffix clear aria-label="Clear text" onClick={() => setValue('')} />
       </Combobox>
     </>
   );

--- a/packages/textfield/stories/Textfield.stories.tsx
+++ b/packages/textfield/stories/Textfield.stories.tsx
@@ -34,13 +34,13 @@ export const autoFocus = () => <TextField autoFocus />;
 
 export const clearPrefix = () => (
   <TextField>
-    <Affix prefix clear onClick={() => alert('clear')} />
+    <Affix prefix clear aria-label="Clear text" onClick={() => alert('clear')} />
   </TextField>
 );
 
 export const searchPrefix = () => (
   <TextField>
-    <Affix prefix search onClick={() => alert('search')} />
+    <Affix prefix search aria-label="Search" onClick={() => alert('search')} />
   </TextField>
 );
 
@@ -52,13 +52,13 @@ export const labelPrefix = () => (
 
 export const clearSuffix = () => (
   <TextField>
-    <Affix suffix clear onClick={() => alert('clear')} />
+    <Affix suffix clear aria-label="Clear text" onClick={() => alert('clear')} />
   </TextField>
 );
 
 export const searchSuffix = () => (
   <TextField>
-    <Affix suffix search onClick={() => alert('search')} />
+    <Affix suffix search aria-label="Search" onClick={() => alert('search')} />
   </TextField>
 );
 
@@ -70,7 +70,7 @@ export const labelSuffix = () => (
 export const suffixAndPrefix = () => (
   <TextField>
     <Affix prefix label="kr" />
-    <Affix suffix clear onClick={() => alert('clear')} />
+    <Affix suffix clear aria-label="Clear text" onClick={() => alert('clear')} />
   </TextField>
 );
 


### PR DESCRIPTION
Fixes [WARP-337](https://nmp-jira.atlassian.net/browse/WARP-337)

Previously the `clear` and `search` Affix button would be announced using its icon's title, which describes the appearance of the icon. However, to satisfy the regulations, the Affix button’s aria-label should describe the purpose of the button, i.e. "Clear text", "Search". A11y team doesn't agree with this and says that we should rather describe its appearance, but Uu-tilsynet’s regulations trump those personal views.

In this PR we pass respective `aria-labels` to Affix components that render as buttons with icons. This means icons title will not be announced, but just the provided aria-label.