### PR TITLE
chore(deps): update @warp-ds/css to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@chbphone55/classnames": "^2.0.0",
     "@lingui/core": "^4.3.0",
     "@warp-ds/core": "^1.0.0",
-    "@warp-ds/css": "^1.3.0",
+    "@warp-ds/css": "^1.4.1",
     "@warp-ds/uno": "^1.1.0",
     "@warp-ds/icons": "1.3.0-next.2",
     "react-focus-lock": "^2.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: ^1.0.0
     version: 1.0.0
   '@warp-ds/css':
-    specifier: ^1.3.0
-    version: 1.3.0
+    specifier: ^1.4.1
+    version: 1.4.1
   '@warp-ds/icons':
     specifier: 1.3.0-next.2
     version: 1.3.0-next.2
@@ -3910,7 +3910,6 @@ packages:
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-    dev: true
 
   /@jridgewell/trace-mapping@0.3.17:
     resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
@@ -5610,7 +5609,6 @@ packages:
 
   /@unocss/core@0.57.1:
     resolution: {integrity: sha512-cqQW/4gCuk+bFMPg9lBanuRNQ9Lx1l4PpMN/6uKxI5WROpq7ce/Xb4uGvAxKLh3ITtFSpXs2cLfsy7QD6cVD/Q==}
-    dev: true
 
   /@unocss/extractor-arbitrary-variants@0.52.7:
     resolution: {integrity: sha512-nJ4iE7nIRpoOIQfD8S58yG4qJd6AhVPEfEOf7ksX1u8xLf71rrBIojwraRXvv7aPqNdZiWvXdh/znpA/QC5b9w==}
@@ -5622,7 +5620,6 @@ packages:
     resolution: {integrity: sha512-9s+azHhBnwjxm46TsD1RY0krDAwOR8tcw58Vtl3emd6C0VQsAOdoprt7UHE7GEXMvDVq7nMf8lAT0BM0LteW3w==}
     dependencies:
       '@unocss/core': 0.57.1
-    dev: true
 
   /@unocss/inspector@0.57.1:
     resolution: {integrity: sha512-qV7ta7iHGX2EpZJ4IWY/05kgyhKFeWlvVJbrOnGsaH8gVt33T/43YAhB/8K5GIXBXIwkhwk13iB13nlg2gSheg==}
@@ -5676,7 +5673,6 @@ packages:
       '@unocss/core': 0.57.1
       '@unocss/extractor-arbitrary-variants': 0.57.1
       '@unocss/rule-utils': 0.57.1
-    dev: true
 
   /@unocss/preset-tagify@0.57.1:
     resolution: {integrity: sha512-GV8knxnsOVH/XiG2KB+mVZeEJqr0PZvvkSTPftGPbjttoKVZ+28Y5q9/qezH7p4W6RYVAAK+3qHHy5wWZosiMw==}
@@ -5725,7 +5721,6 @@ packages:
     dependencies:
       '@unocss/core': 0.57.1
       magic-string: 0.30.5
-    dev: true
 
   /@unocss/scope@0.57.1:
     resolution: {integrity: sha512-ZAzg6lLGwKNQGCvJXEie3TvGztkAyajEFqygu0mjtHb+CmDql4iAjoygs+3dnRI5hSDwfMYFrJ2azX26+2CsoA==}
@@ -5820,11 +5815,11 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/css@1.3.0:
-    resolution: {integrity: sha512-RFq9rqsRz581RB3/VfeDIebGDGbjKDbARqTSPP1tOBjUo/+mBJ80Z1RP7DV0Q3bUi+5tAz8TuPBCZcoQqToSxw==}
+  /@warp-ds/css@1.4.1:
+    resolution: {integrity: sha512-AgVOEU4f023CKTMxTnH8+BTNhGjAVux88EeIR/ikch5FM2nArCTpp7af8/qGZOhc7QDegJvHlt6DcCR7rqyIQg==}
     dependencies:
       '@warp-ds/tokenizer': 0.0.2
-      '@warp-ds/uno': 1.1.0
+      '@warp-ds/uno': 1.2.0
     dev: false
 
   /@warp-ds/icons@1.3.0-next.2:
@@ -5845,6 +5840,14 @@ packages:
     dependencies:
       '@unocss/core': 0.55.3
       '@unocss/preset-mini': 0.52.7
+    dev: false
+
+  /@warp-ds/uno@1.2.0:
+    resolution: {integrity: sha512-P5zq8/Bzg33HXR0UxupqJROZK3/QFJOc+bzABN3qTihPCkiqLJCWHxqf2a61Bleg1yK4mTQv+J3FRfYyeZCUow==}
+    dependencies:
+      '@unocss/core': 0.57.1
+      '@unocss/preset-mini': 0.57.1
+      '@unocss/rule-utils': 0.57.1
     dev: false
 
   /@yarnpkg/esbuild-plugin-pnp@3.0.0-rc.15(esbuild@0.17.18):
@@ -10054,7 +10057,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
 
   /make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}


### PR DESCRIPTION
@warp-ds/css v1.4.1 introduces the following fixes:

- **expandable**: fix long titles overflowing chevron (https://github.com/warp-ds/css/issues/89) ([9de1b4c](https://github.com/warp-ds/css/commit/9de1b4cc1bd28620fefb6f30e58acfd20d7c4119))
- **expandable**: Only show focus indicator in Expandable component on focus-visible (https://github.com/warp-ds/css/issues/84) ([ccf30f2](https://github.com/warp-ds/css/commit/ccf30f2f9e20a93477cc7f5cf9dc602293320fc6))
- **tabs**: left align all tabs instead of stretch ([9b88498](https://github.com/warp-ds/css/commit/9b884986a0cff63f4e5dbd6fb8c2561331989291))
- **modal**: Z-index of Modal backdrop should be 30 according to css docs (https://github.com/warp-ds/css/issues/90) ([436b9d0](https://github.com/warp-ds/css/commit/436b9d0e5970eff412740d5758517921c928bef3))
