### PR TITLE
fix(textfield): allow styling input's left padding if prefix is wider than 40px

### DIFF
--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -46,6 +46,14 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
           className={className}
           style={style}
         >
+          {/* we style input with prefix here because we cannot use arbitrary values with commas in UnoCSS like pl-[var(--w-prefix-width, 40px)] */}
+          <style>
+            {`
+              div+#${id}, button+#${id} {
+                padding-left:var(--w-prefix-width, 40px);
+              }
+            `}
+          </style>
           {label && (
             <label htmlFor={id} className={classNames({
               [ccLabel.label]: true,

--- a/packages/textfield/stories/Textfield.stories.tsx
+++ b/packages/textfield/stories/Textfield.stories.tsx
@@ -50,6 +50,12 @@ export const labelPrefix = () => (
   </TextField>
 );
 
+export const longLabelPrefix = () => (
+  <TextField className="[--w-prefix-width:90px]" value="With some value">
+    <Affix prefix label="Long prefix" />
+  </TextField>
+);
+
 export const clearSuffix = () => (
   <TextField>
     <Affix suffix clear aria-label="Clear text" onClick={() => alert('clear')} />


### PR DESCRIPTION
Fixes [WARP-374](https://nmp-jira.atlassian.net/browse/WARP-374)

Prefix is an absolutely positioned component and the gap between that component and the `input`'s content is handled using a left padding on the `input`. It’s currently hard-coded to 40px, but with this quick fix we can let users change it by setting a CSS variable in `TextField`’s class (`<TextField class=”[--w-prefix-wdith: 100px]”>`). It’s not dynamic and users will need to calculate how much padding their input needs, but it’s the only non-breaking quick fix we managed to come up with. We should really consider rewriting these form components completely to properly approach styling of different text fields, affixes etc.

<img width="464" alt="Screenshot with long prefix" src="https://github.com/warp-ds/react/assets/41303231/cc3300d8-d4d0-4cc4-8666-8dc0688cb3a2">
<img width="452" alt="Screenshot with 2-letter prefix" src="https://github.com/warp-ds/react/assets/41303231/ff500993-0a96-48bc-9eec-5c1559c313d4">
<img width="454" alt="Screenshot with no prefix" src="https://github.com/warp-ds/react/assets/41303231/ac9c56e2-410a-4774-a959-98b4c4343168">
