### PR TITLE
chore(crowdin sync): use new features

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -15,3 +15,5 @@ jobs:
   synchronize-with-crowdin:
     uses: warp-ds/reusable-workflows/.github/workflows/crowdin-sync.yml@main
     secrets: inherit
+    with:
+      pull_request_reviewers: "BalbinaK"

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -9,6 +9,7 @@ on:
     # avoid crashing with other workflows.
     - cron: "0 8-17/2 * * 1-5" # At minute 0 past every 2nd hour from 8 through 17 on every day-of-week from Monday through Friday (https://crontab.guru/#0_8-17/2_*_*_1-5)
   workflow_dispatch:
+  pull_request_review_comment:
 
 jobs:
   synchronize-with-crowdin:


### PR DESCRIPTION
Fixes [WARP-418](https://nmp-jira.atlassian.net/browse/WARP-418)

This PR uses the following features of our [reusable crowdin-sync workflow](https://github.com/warp-ds/reusable-workflows)
1. Set a default Crowdin PR reviewer for this repo
2. Forward Crowdin PR comments to Crowdin translators. Unfortunately, the translators won't be able to respond to our comments directly in the PR due to the fact that they are using schibsted enterprise email accounts in Crowdin + Github, and those cannot be added to a public GH organisation. Still, this one-way communication may prove useful when we spot typos or other mistakes in the suggested changes.