### PR TITLE
fix: add header classes modal

### DIFF
--- a/packages/modal/src/component.tsx
+++ b/packages/modal/src/component.tsx
@@ -111,8 +111,9 @@ export const Modal = ({
               id={`${id}__title`}
               className={classNames(
                 ccModal.transitionTitle,
+                ccModal.transitionTitleMaxWidth,
                 !!props.left
-                  ? ccModal.transitionTitleCenter
+                  ? [ccModal.transitionTitleCenter, ccModal.transitionTitleColSpan]
                   : ccModal.transitionTitleColSpan
               )}
             >

--- a/packages/modal/src/component.tsx
+++ b/packages/modal/src/component.tsx
@@ -75,7 +75,10 @@ export const Modal = ({
           className={ccModal.modal}
           tabIndex={-1}
         >
-          <div className={ccModal.title}>
+          <div className={classNames(
+            ccModal.title,
+            props.headerClasses
+            )}>
             {typeof props.left === "boolean" && props.left ? (
               <button
                 type="button"

--- a/packages/modal/src/props.ts
+++ b/packages/modal/src/props.ts
@@ -63,4 +63,10 @@ export type ModalProps = {
    * A reference to the element that should be focused. By default it'll be the first interactive element.
    */
   initialFocusRef?: React.RefObject<any>;
+
+    /**
+   * Classes here will be set on the wrapper for the header.
+   */
+    headerClasses?: string | JSX.Element;
+
 };

--- a/packages/modal/stories/Modal.stories.tsx
+++ b/packages/modal/stories/Modal.stories.tsx
@@ -214,3 +214,47 @@ export const Overflowing = () => {
     </>
   );
 };
+
+export const ExampleWithLongTitle = () => {
+  const [open, setOpen] = React.useState(true);
+  const toggleModal = () => setOpen(!open);
+  const openModalRef = React.useRef<HTMLButtonElement>(null);
+
+  React.useEffect(() => {
+    if (!open) {
+      openModalRef.current?.focus();
+    }
+  }, [open]);
+
+  return (
+    <>
+      <Button ref={openModalRef} utility onClick={toggleModal}>
+        Open modal
+      </Button>
+      <Modal
+        open={open}
+        onDismiss={toggleModal}
+        headerClasses={"h-full"}
+        title="Title of the content goes here, and for this example we have chosen a long title!"
+        footer={
+          <>
+            <Button onClick={toggleModal} className="mr-12">
+              Cancel
+            </Button>
+            <Button primary onClick={toggleModal}>
+              Accept
+            </Button>
+          </>
+        }
+      >
+        <p>
+          Content information goes here. Optional illustration on top. Can
+          contain links.
+        </p>
+        <a href="#" onClick={(event) => event.preventDefault()}>
+          Optional link to read more.
+        </a>
+      </Modal>
+    </>
+  );
+};

--- a/packages/modal/stories/Modal.stories.tsx
+++ b/packages/modal/stories/Modal.stories.tsx
@@ -233,9 +233,10 @@ export const ExampleWithLongTitle = () => {
       </Button>
       <Modal
         open={open}
+        right
         onDismiss={toggleModal}
-        headerClasses={"h-full"}
-        title="Title of the content goes here, and for this example we have chosen a long title!"
+        title="Title of the content goes here, and here we have chosen a long title!"
+        headerClasses={"h-full sm:h-full"}
         footer={
           <>
             <Button onClick={toggleModal} className="mr-12">


### PR DESCRIPTION
**Note:** Once [this PR](https://github.com/warp-ds/css/pull/116) has been merged and we have published a new version of @warp-ds/css, we need to update the version of @warp-ds/css in the package.json before this PR can be merged.

These changes are part of fixes for this JIRA ticket: [WARP-429](https://nmp-jira.atlassian.net/browse/WARP-429)

- Added `headerClasses` prop to Modal + added it to modal-example, changing the height of the modal title to `h-full sm:h-full`.
- Adjusted styling for the modal title after changes made in [this PR](https://github.com/warp-ds/css/pull/116)

**To test:** Link this branch with branch from the css-repo: `fix/refactor-modal-style`
