### PR TITLE
feat(modal): add onLeftClick prop to control left button event-handling

### DIFF
--- a/packages/modal/src/component.tsx
+++ b/packages/modal/src/component.tsx
@@ -91,7 +91,7 @@ export const Modal = ({
                   ccModal.titleButton,
                   ccModal.titleButtonLeft
                 )}
-                onClick={props.onDismiss}
+                onClick={props.onLeftClick ? props.onLeftClick : props.onDismiss}
               >
                 <IconTableSortDown16
                   className={classNames(

--- a/packages/modal/src/props.ts
+++ b/packages/modal/src/props.ts
@@ -50,6 +50,11 @@ export type ModalProps = {
   onDismiss?: () => void;
 
   /**
+   * Handler that is called when the user clicks the left button
+   */
+  onLeftClick?: () => void;
+
+  /**
    * Defines a string value that labels the current element. Must be set if neither `aria-labelledby` or `<ModalHeading>` is defined,
    */
   'aria-label'?: string;

--- a/packages/modal/stories/Modal.stories.tsx
+++ b/packages/modal/stories/Modal.stories.tsx
@@ -70,6 +70,10 @@ export const WithBackAndCloseButton = () => {
         left
         right
         onDismiss={toggleModal}
+        onLeftClick={() => {
+          console.log('left clicked');
+          toggleModal();
+        }}
         title="Title of the content goes here"
         footer={
           <>


### PR DESCRIPTION
This will align Vue and React Modal's API, as well as solve a problem where it wasn't possible to reuse the default back button to go to the previous step in a multi-page Modal.