### PR TITLE
fix: rename deleted icons after @warp-ds/icons update to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@lingui/core": "4.7.0",
     "@warp-ds/core": "1.0.2",
     "@warp-ds/css": "1.8.0",
-    "@warp-ds/icons": "1.5.1",
+    "@warp-ds/icons": "2.0.0",
     "@warp-ds/uno": "1.8.0",
     "react-focus-lock": "2.9.7",
     "resize-observer-polyfill": "1.5.1",

--- a/packages/alert/src/component.tsx
+++ b/packages/alert/src/component.tsx
@@ -3,10 +3,10 @@ import React, { PropsWithChildren, ReactElement } from "react";
 import { alert as ccAlert } from "@warp-ds/css/component-classes";
 import { AlertProps } from "./props.js";
 import { ExpandTransition } from "../../_helpers/index.js";
-import IconAlertError16 from '@warp-ds/icons/react/alert-error-16';
-import IconAlertInfo16 from '@warp-ds/icons/react/alert-info-16';
-import IconAlertSuccess16 from '@warp-ds/icons/react/alert-success-16';
-import IconAlertWarning16 from '@warp-ds/icons/react/alert-warning-16';
+import IconError16 from '@warp-ds/icons/react/error-16';
+import IconInfo16 from '@warp-ds/icons/react/info-16';
+import IconSuccess16 from '@warp-ds/icons/react/success-16';
+import IconWarning16 from '@warp-ds/icons/react/warning-16';
 
 export function Alert({
   show,
@@ -40,8 +40,8 @@ export function Alert({
 const iconMap: {
   [key in AlertProps["type"]]: ReactElement;
 } = {
-  negative: <IconAlertError16 />,
-  positive: <IconAlertSuccess16 />,
-  warning: <IconAlertWarning16 />,
-  info: <IconAlertInfo16 />,
+  negative: <IconError16 />,
+  positive: <IconSuccess16 />,
+  warning: <IconWarning16 />,
+  info: <IconInfo16 />,
 };

--- a/packages/alert/stories/Alert.stories.tsx
+++ b/packages/alert/stories/Alert.stories.tsx
@@ -50,19 +50,19 @@ Variants.play = async ({ canvasElement }) => {
   // test the outer container
   await expect(negative.getByRole('alert')).toBeInTheDocument();
   // test the icon
-  await expect(negative.getByTitle(/Red octagon/)).toBeInTheDocument();
+  await expect(negative.getByTitle(/Octagon/)).toBeInTheDocument();
   
   const positive = within(canvas.getByTestId('positive'));
   await expect(positive.getByRole('status')).toBeInTheDocument();
-  await expect(positive.getByTitle(/Green circle/)).toBeInTheDocument();
+  await expect(positive.getByTitle(/checkmark/)).toBeInTheDocument();
   
   const warning = within(canvas.getByTestId('warning'));
   await expect(warning.getByRole('alert')).toBeInTheDocument();
-  await expect(warning.getByTitle(/Yellow warning/)).toBeInTheDocument();
+  await expect(warning.getByTitle(/Warning/)).toBeInTheDocument();
   
   const info = within(canvas.getByTestId('info'));
   await expect(info.getByRole('status')).toBeInTheDocument();
-  await expect(info.getByTitle(/Blue circle/)).toBeInTheDocument();
+  await expect(info.getByTitle(/Information/)).toBeInTheDocument();
 };
 
 const InteractiveContent = ({type}: Pick<AlertProps, "type">) => (

--- a/packages/modal/src/component.tsx
+++ b/packages/modal/src/component.tsx
@@ -11,7 +11,7 @@ import { messages as enMessages } from "./locales/en/messages.mjs";
 import { messages as fiMessages } from "./locales/fi/messages.mjs";
 import { activateI18n } from "../../i18n.js";
 import IconClose16 from '@warp-ds/icons/react/close-16';
-import IconTableSortDown16 from '@warp-ds/icons/react/table-sort-down-16';
+import IconArrowLeft16 from '@warp-ds/icons/react/arrow-left-16';
 
 /**
  * A Modal dialog that renders on top the page
@@ -93,11 +93,8 @@ export const Modal = ({
                 )}
                 onClick={props.onLeftClick ? props.onLeftClick : props.onDismiss}
               >
-                <IconTableSortDown16
-                  className={classNames(
-                    ccModal.titleButtonIcon,
-                    ccModal.titleButtonIconRotated
-                  )}
+                <IconArrowLeft16
+                  className={classNames(ccModal.titleButtonIcon)}
                 />
               </button>
             ) : (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ dependencies:
     specifier: 1.8.0
     version: 1.8.0
   '@warp-ds/icons':
-    specifier: 1.5.1
-    version: 1.5.1
+    specifier: 2.0.0
+    version: 2.0.0
   '@warp-ds/uno':
     specifier: 1.8.0
     version: 1.8.0
@@ -6300,8 +6300,8 @@ packages:
       '@warp-ds/uno': 1.8.0
     dev: false
 
-  /@warp-ds/icons@1.5.1:
-    resolution: {integrity: sha512-v3i3iYWz7EFhFvNls5+HpE/oCWpkLaq0LpG5zlFQBUCkDgSle/5gCjnKtdGwR8bW+E9VDfoVRwhpaGg8f9kL9w==}
+  /@warp-ds/icons@2.0.0:
+    resolution: {integrity: sha512-a6Zi9CEunu5V0ScfaG42j5LoPK/U9uL5Gcv+/4D9FNQjaPuissqflUL3YpYI2PxTMIrHuyYXfUMWu8gBVGoUdg==}
     dependencies:
       '@lingui/core': 4.7.0
     dev: false
@@ -11522,7 +11522,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
     dev: true
 
   /jsonparse@1.3.1:
@@ -11622,7 +11622,7 @@ packages:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
     engines: {node: '>=4'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       parse-json: 4.0.0
       pify: 3.0.0
       strip-bom: 3.0.0


### PR DESCRIPTION
## Description
Fixes [WARP-498](https://nmp-jira.atlassian.net/browse/WARP-498)

This PR updates @warp-ds/icons dependency to 2.0.0 and replaces deprecated icons with the [suggested equivalents](https://warp-ds.github.io/tech-docs/components/icons/#deprecated-icons):

## What's changed
### Rename deprecated alert- icons in Alert component 
<img width="362" alt="Screenshot of Alert component variants with the new outlined icons" src="https://github.com/warp-ds/react/assets/41303231/688ea807-fa1c-40e2-8cdb-61fddf8b8d79">

### Use arrow-left icon as back button in Modal component:
<img width="466" alt="Screenshot of Modal component with back button using an arrow-left icon" src="https://github.com/warp-ds/react/assets/41303231/4fb318c3-cf6a-44be-9a93-7bef7f36f88a">
