### PR TITLE
test(pagination): add tests to get 100% coverage

### DIFF
--- a/packages/pagination/src/CurrentPage.tsx
+++ b/packages/pagination/src/CurrentPage.tsx
@@ -15,10 +15,6 @@ const CurrentPage = React.forwardRef<HTMLDivElement, CurrentPageProps>(
   ({ children, className, ...props }, ref) => {
     const { currentPage } = usePagination();
 
-    if (currentPage < 1) {
-      return null;
-    }
-
     const label =
       children ??
       i18n._({

--- a/packages/pagination/src/Page.tsx
+++ b/packages/pagination/src/Page.tsx
@@ -29,10 +29,7 @@ export type PageProps = {
 const Page = React.forwardRef<
   React.AnchorHTMLAttributes<HTMLAnchorElement>,
   PageProps
->(({ page = 0, className, currentPage, ...props }, ref) => {
-  if (page < 1) {
-    return null;
-  }
+>(({ page = 1, className, currentPage, ...props }, ref) => {
 
   const isCurrentPage = page === currentPage;
 

--- a/packages/pagination/src/PrevPage.tsx
+++ b/packages/pagination/src/PrevPage.tsx
@@ -30,7 +30,7 @@ const PrevPage = React.forwardRef<
 >(({ className, ...props }, ref) => {
   const { currentPage } = usePagination();
 
-  if (currentPage <= 1) {
+  if (currentPage === 1) {
     return null;
   }
 

--- a/tests/components/PaginationTest.tsx
+++ b/tests/components/PaginationTest.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Pagination } from '../../packages/pagination/src/index.js';
 
@@ -14,6 +14,10 @@ describe('Pagination component', () => {
             createHref={(page) => `?page=${page}`}
             onChange={onChangeFunction} />);
     });
+    
+    afterEach(() => {
+        vi.resetAllMocks();
+    })
 
     it('renders', () => {
         expect(screen.getByText('Pages')).toBeInTheDocument();
@@ -37,3 +41,33 @@ describe('Pagination component', () => {
         expect(onChangeFunction).toHaveBeenCalledWith(1);
     });
 });
+
+it('calls on change function on click of previous page', () => {
+    render(<Pagination currentPage={13}
+        numPages={13}
+        lastPage={13}
+        createHref={(page) => `?page=${page}`}
+        onChange={onChangeFunction} />
+    );
+    
+    expect(screen.getByRole('link', { name: 'Previous page, icon' })).toHaveTextContent('Leftward arrow');
+    fireEvent.click(screen.getByRole('link', { name: 'Previous page, icon' }));
+
+    expect(onChangeFunction).toHaveBeenCalledTimes(1);
+    expect(onChangeFunction).toHaveBeenCalledWith(12);
+})
+
+it('should throw error if currentPage is not a number', () => {
+    // @ts-ignore
+    expect(() => render(<Pagination currentPage={undefined} lastPage={2} createHref={(page) => `?page=${page}`} onChange={onChangeFunction} />)).toThrowError('Invalid currentPage: undefined');
+})
+
+it('should throw error if lastPage is not a number', () => {
+    // @ts-ignore
+    expect(() => render(<Pagination currentPage={1} lastPage={undefined} createHref={(page) => `?page=${page}`} onChange={onChangeFunction} />)).toThrowError('Invalid lastPage: undefined');
+})
+
+it('should throw error if createHref is not a function', () => {
+    // @ts-ignore
+    expect(() => render(<Pagination currentPage={1} lastPage={2} createHref={undefined} onChange={onChangeFunction} />)).toThrowError('createHref is undefined');
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -21,6 +21,7 @@ export default function config(env) {
       exclude: ['**.json'],
       coverage: {
         cleanOnRerun: true,
+        skipFull: true,
         reporter: ['text'],
         exclude: [
           "**.json",


### PR DESCRIPTION
## Description
We are aiming at adding unit tests to all components and having test coverage at 100%. This PR does that for Pagination component.

## What's changed
- added tests erroneous states
- removed redundant safeguards for prop values lower than 1 (`usePagination()` hook always sets page number values to at least 1)
- set a `skipFull` flag to `true` to not show test coverage of components that are already at 100% (reduces noise)