### PR TITLE
fix(toggle): only allow label to be 'small' when type is 'radio-button'

### DIFF
--- a/packages/toggle/src/component.tsx
+++ b/packages/toggle/src/component.tsx
@@ -73,7 +73,7 @@ export function Toggle(props: ToggleProps) {
     [ccToggle.icon]: isCheckbox && !props.indeterminate,
     [ccToggle.checkboxInvalid]: isCheckbox && isInvalid,
     [ccToggle.radioButtonsLabel]: isRadioButton,
-    [ccToggle.radioButtonsLabelSmall]: props.small,
+    [ccToggle.radioButtonsLabelSmall]: props.small && isRadioButton,
   });
   const inputClasses = classNames({
     [ccToggle.input]: true,


### PR DESCRIPTION
According to our design, only Toggle of type 'radio-button' should be possible to made "small". There are no small checkbox or radio Toggles in our library.