### PR TITLE
fix(modal): cleanup scroll lock when modal component unmounts

### DIFF
--- a/packages/modal/src/component.tsx
+++ b/packages/modal/src/component.tsx
@@ -28,6 +28,13 @@ export const Modal = ({
   activateI18n(enMessages, nbMessages, fiMessages);
 
   useEffect(() => {
+    // Cleanup scroll lock if component unmounts before it receives an updated
+    // open prop and is closed. Can happen if the host conditionally renders the
+    // modal.
+    return () => teardown();
+  }, []);
+
+  useEffect(() => {
     teardown();
     if (!contentRef.current) return;
     props.open && setup(contentRef.current);


### PR DESCRIPTION
This change fixes a problem with the page scroll remaining locked when the modal component is unmounted before it is closed. This can happen if the host is conditionally rendering the modal.