### PR TITLE
fix(useId): return fallback ID for React v17

### DIFF
--- a/packages/utils/src/useId.ts
+++ b/packages/utils/src/useId.ts
@@ -3,10 +3,13 @@ import React from 'react';
 const useReactId = React.useId;
 
 export const useId = (hasFallback?): string => {
+  if (hasFallback) {
+    return hasFallback;
+  }
   if (typeof useReactId === 'function') {
     // reactUseId returns a string that includes colons (:), e.g., :r0:, :r1:, etc.
     // This string is NOT supported in CSS selectors. Hence the replace.
-    return hasFallback ?? useReactId().replace(/:/g, '');
+    return useReactId().replace(/:/g, '');
   } else {
     const [elId] = React.useState(generateId());
     return elId;


### PR DESCRIPTION
With this PR, the provided fallback ID is also returned when `React.useId` is not supported. This is the case for React v17.