### PR TITLE
fix: Expandable info box background color

### DIFF
--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -49,6 +49,7 @@ export function Expandable(props: ExpandableProps) {
       className={classNames(className, {
         [ccExpandable.expandable]: true,
         [ccExpandable.expandableBox]: box,
+        [ccExpandable.expandableInfo]: info,
         [ccExpandable.expandableBleed]: bleed,
       })}
     >


### PR DESCRIPTION
Needs new component-class from: https://github.com/warp-ds/css/pull/175

Solves: https://sch-chat.slack.com/archives/C04P0GYTHPV/p1709545888447519