### PR TITLE
fix(toggle): fix styling in different states

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,9 +109,9 @@
     "@chbphone55/classnames": "2.0.0",
     "@lingui/core": "4.7.0",
     "@warp-ds/core": "1.0.2",
-    "@warp-ds/css": "1.8.3",
+    "@warp-ds/css": "1.8.4-next.3",
     "@warp-ds/icons": "2.0.0",
-    "@warp-ds/uno": "1.8.1",
+    "@warp-ds/uno": "1.9.0",
     "react-focus-lock": "2.9.7",
     "resize-observer-polyfill": "1.5.1",
     "scroll-doctor": "2.0.2"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@chbphone55/classnames": "2.0.0",
     "@lingui/core": "4.7.0",
     "@warp-ds/core": "1.0.2",
-    "@warp-ds/css": "1.8.4-next.3",
+    "@warp-ds/css": "1.8.4",
     "@warp-ds/icons": "2.0.0",
     "@warp-ds/uno": "1.9.0",
     "react-focus-lock": "2.9.7",

--- a/packages/_helpers/dead-toggle.tsx
+++ b/packages/_helpers/dead-toggle.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { classNames } from '@chbphone55/classnames';
-import { toggle as ccToggle } from '@warp-ds/css/component-classes';
+import { deadToggle as ccDeadToggle } from '@warp-ds/css/component-classes';
 import { Item } from '../toggle/src/item.js';
 
 export interface DeadToggleProps {
@@ -38,33 +38,18 @@ export interface DeadToggleProps {
 export function DeadToggle(props: DeadToggleProps) {
   const type = props.radio ? 'radio' : 'checkbox';
 
-  const labelClasses = classNames(props.labelClassName, {
-    [ccToggle.label]: true,
-    [ccToggle.focusable]: true,
-    [ccToggle.noContent]: true,
-    [`${ccToggle.radio} ${ccToggle.labelRadioBorder} ${ccToggle.radioChecked}`]: props.radio,
-    [`${ccToggle.checkbox} ${ccToggle.labelCheckboxBorder} ${ccToggle.checkboxChecked}`]: props.checkbox,
-    [ccToggle.icon]: props.checkbox,
-  });
-  const inputClasses = classNames({
-    [ccToggle.input]: true,
-    [ccToggle.a11y]: true,
-    [ccToggle.deadToggleInput]: true,
-  });
-
-  const wrapperClasses = {
-    [ccToggle.wrapper]: true,
-    [ccToggle.deadToggleWrapper]: true,
-  };
   return (
     <div
-      className={classNames(props.className, wrapperClasses)}
+      className={classNames(props.className, ccDeadToggle.wrapper)}
       aria-hidden="true"
     >
       <Item
         type={type}
-        className={inputClasses}
-        labelClassName={labelClasses}
+        inputClassName={ccDeadToggle.input}
+        labelClassName={classNames(props.labelClassName, {
+          [ccDeadToggle.labelRadio]: props.radio,
+          [ccDeadToggle.labelCheckbox]: props.checkbox,
+        })}
         name="dead-toggle"
         controlled={true}
         onChange={() => undefined}

--- a/packages/toggle/src/component.tsx
+++ b/packages/toggle/src/component.tsx
@@ -54,27 +54,27 @@ function HelpText({ isInvalid, helpId, helpText }: any) {
 export function Toggle(props: ToggleProps) {
   const id = useId();
   const helpId = props.helpText ? `${id}__hint` : undefined;
-  const isInvalid = props.invalid;
-  const isIndeterminate = props.indeterminate;
   const isRadio = props.type === 'radio';
   const isCheckbox = props.type === 'checkbox';
   const isRadioButton = props.type === 'radio-button';
   const isRadioGroup = isRadio || isRadioButton;
-  const isControlled =
-    props.selected !== undefined || props.checked !== undefined;  
+  const isIndeterminate = isCheckbox && props.indeterminate;
+  const isInvalid = props.invalid;
   const isDisabled = !isRadioButton && props.disabled;
+  const isControlled = props.selected !== undefined || props.checked !== undefined;
 
   const labelClasses = classNames({
     [ccToggle.label]: !isRadioButton,
     [ccToggle.labelBefore]: !isRadioButton && !isIndeterminate,
-    [ccToggle.indeterminate]: isCheckbox && isIndeterminate && !isDisabled,
-    [ccToggle.indeterminateDisabled]: isCheckbox && isIndeterminate && isDisabled,
+    [ccToggle.checkbox]: isCheckbox && !isIndeterminate && !isInvalid && !isDisabled,
+    [ccToggle.checkboxInvalid]: isCheckbox && !isIndeterminate && isInvalid && !isDisabled,
+    [ccToggle.checkboxDisabled]: isCheckbox && !isIndeterminate && !isInvalid && isDisabled,
+    [ccToggle.indeterminate]: isCheckbox&& isIndeterminate && !isInvalid && !isDisabled,
+    [ccToggle.indeterminateInvalid]: isCheckbox && isIndeterminate && isInvalid && !isDisabled,
+    [ccToggle.indeterminateDisabled]: isCheckbox && isIndeterminate && !isInvalid && isDisabled,
     [ccToggle.radio]: isRadio && !isInvalid && !isDisabled,
     [ccToggle.radioInvalid]: isRadio && isInvalid && !isDisabled,
     [ccToggle.radioDisabled]: isRadio && !isInvalid && isDisabled,
-    [ccToggle.checkbox]: isCheckbox && !isIndeterminate && !isInvalid && !isDisabled,
-    [ccToggle.checkboxInvalid]: isCheckbox && isInvalid && !isDisabled,
-    [ccToggle.checkboxDisabled]: isCheckbox && !isInvalid && isDisabled,
     [ccToggle.radioButtonsLabel]: isRadioButton,
     [ccToggle.radioButtonsRegular]: isRadioButton && !props.small,
     [ccToggle.radioButtonsSmall]: isRadioButton && props.small,

--- a/packages/toggle/src/component.tsx
+++ b/packages/toggle/src/component.tsx
@@ -62,15 +62,19 @@ export function Toggle(props: ToggleProps) {
   const isRadioGroup = isRadio || isRadioButton;
   const isControlled =
     props.selected !== undefined || props.checked !== undefined;  
+  const isDisabled = !isRadioButton && props.disabled;
 
   const labelClasses = classNames({
     [ccToggle.label]: !isRadioButton,
     [ccToggle.labelBefore]: !isRadioButton && !isIndeterminate,
-    [ccToggle.indeterminate]: isCheckbox && isIndeterminate,
-    [ccToggle.radio]: isRadio && !isInvalid,
-    [ccToggle.radioInvalid]: isRadio && isInvalid,
-    [ccToggle.checkbox]: isCheckbox && !isIndeterminate && !isInvalid,
-    [ccToggle.checkboxInvalid]: isCheckbox && isInvalid,
+    [ccToggle.indeterminate]: isCheckbox && isIndeterminate && !isDisabled,
+    [ccToggle.indeterminateDisabled]: isCheckbox && isIndeterminate && isDisabled,
+    [ccToggle.radio]: isRadio && !isInvalid && !isDisabled,
+    [ccToggle.radioInvalid]: isRadio && isInvalid && !isDisabled,
+    [ccToggle.radioDisabled]: isRadio && !isInvalid && isDisabled,
+    [ccToggle.checkbox]: isCheckbox && !isIndeterminate && !isInvalid && !isDisabled,
+    [ccToggle.checkboxInvalid]: isCheckbox && isInvalid && !isDisabled,
+    [ccToggle.checkboxDisabled]: isCheckbox && !isInvalid && isDisabled,
     [ccToggle.radioButtonsLabel]: isRadioButton,
     [ccToggle.radioButtonsRegular]: isRadioButton && !props.small,
     [ccToggle.radioButtonsSmall]: isRadioButton && props.small,
@@ -124,6 +128,7 @@ export function Toggle(props: ToggleProps) {
             name={`${id}:toggle`}
             key={`${id + props.type}`}
             invalid={isInvalid}
+            disabled={isDisabled}
             helpId={helpId}
             type={isRadioGroup ? 'radio' : 'checkbox'}
             noVisibleLabel={props.noVisibleLabel}
@@ -146,6 +151,7 @@ export function Toggle(props: ToggleProps) {
               name={`${id}:toggle`}
               key={`${id + i + props.type}`}
               invalid={isInvalid}
+              disabled={isDisabled}
               helpId={helpId}
               type={isRadioGroup ? 'radio' : 'checkbox'}
               noVisibleLabel={props.noVisibleLabel}

--- a/packages/toggle/src/component.tsx
+++ b/packages/toggle/src/component.tsx
@@ -82,8 +82,8 @@ export function Toggle(props: ToggleProps) {
 
   const wrapperClasses = classNames(props.className, {
     [ccToggle.wrapper]: true,
-    [`${ccToggle.radioButtons} ${ccToggle.focusableWithin}`]: isRadioButton,
-    [ccToggle.radioButtonsJustified]: props.equalWidth,
+    [ccToggle.wrapperRadioButtons]: isRadioButton && !props.equalWidth,
+    [ccToggle.wrapperRadioButtonsJustified]: isRadioButton && props.equalWidth,
   });
 
   const groupClasses = classNames({

--- a/packages/toggle/src/component.tsx
+++ b/packages/toggle/src/component.tsx
@@ -55,6 +55,7 @@ export function Toggle(props: ToggleProps) {
   const id = useId();
   const helpId = props.helpText ? `${id}__hint` : undefined;
   const isInvalid = props.invalid;
+  const isIndeterminate = props.indeterminate;
   const isRadio = props.type === 'radio';
   const isCheckbox = props.type === 'checkbox';
   const isRadioButton = props.type === 'radio-button';
@@ -63,17 +64,16 @@ export function Toggle(props: ToggleProps) {
     props.selected !== undefined || props.checked !== undefined;  
 
   const labelClasses = classNames({
-    [ccToggle.indeterminate]: props.indeterminate,
     [ccToggle.label]: !isRadioButton,
-    [ccToggle.focusable]: !isRadioButton,
-    [ccToggle.noContent]: !props.indeterminate,
-    [`${ccToggle.radio} ${ccToggle.labelRadioBorder} ${ccToggle.radioChecked}`]: isRadio,
+    [ccToggle.labelBefore]: !isRadioButton && !isIndeterminate,
+    [ccToggle.indeterminate]: isCheckbox && isIndeterminate,
+    [ccToggle.radio]: isRadio && !isInvalid,
     [ccToggle.radioInvalid]: isRadio && isInvalid,
-    [`${ccToggle.checkbox} ${ccToggle.labelCheckboxBorder} ${ccToggle.checkboxChecked}`]: isCheckbox,
-    [ccToggle.icon]: isCheckbox && !props.indeterminate,
+    [ccToggle.checkbox]: isCheckbox && !isIndeterminate && !isInvalid,
     [ccToggle.checkboxInvalid]: isCheckbox && isInvalid,
     [ccToggle.radioButtonsLabel]: isRadioButton,
-    [ccToggle.radioButtonsLabelSmall]: props.small,
+    [ccToggle.radioButtonsRegular]: isRadioButton && !props.small,
+    [ccToggle.radioButtonsSmall]: isRadioButton && props.small,
   });
   const inputClasses = classNames({
     [ccToggle.input]: true,

--- a/packages/toggle/src/props.ts
+++ b/packages/toggle/src/props.ts
@@ -89,4 +89,9 @@ export interface ToggleProps {
    * The checkbox will appear with a small dash instead of a tick to indicate that the option is not exactly checked or unchecked.
    */
   indeterminate?: boolean;
+
+  /**
+   * Whether the toggle is disabled
+   */
+  disabled?: boolean;
 }

--- a/packages/toggle/stories/Checkbox.stories.tsx
+++ b/packages/toggle/stories/Checkbox.stories.tsx
@@ -58,9 +58,12 @@ export const SingleOptionCheckedUncontrolledDefault = () => {
   );
 };
 
-export const IndeterminateState = () => {
+export const IndeterminateState = ({
+    isInvalid = false,
+    isDisabled = false
+  }: { isInvalid?: boolean, isDisabled?: boolean }) => {
   const [selectAllChecked, setSelectAllChecked] = useState(false);
-  const [selectedOptions, setSelectedOptions] = useState<Option[]>([]);
+  const [selectedOptions, setSelectedOptions] = useState<Option[]>([options[0]]);
 
   const handleSelectAll = (checked: boolean) => {
     if (checked === false) {
@@ -99,6 +102,8 @@ export const IndeterminateState = () => {
           selectedOptions.length > 0 &&
           selectedOptions.length !== options.length
         }
+        invalid={isInvalid}
+        disabled={isDisabled}
       />
       <Toggle
         type="checkbox"
@@ -106,10 +111,15 @@ export const IndeterminateState = () => {
         options={options}
         selected={selectedOptions}
         onChange={handleSelect}
+        invalid={isInvalid}
+        disabled={isDisabled}
       />
     </>
   );
 };
+
+export const Invalid = () => <IndeterminateState isInvalid={true} />;
+export const Disabled = () => <IndeterminateState isDisabled={true} />;
 
 export const SingleOptionHelpText = () => {
   return (
@@ -166,43 +176,6 @@ export const HelpText = () => {
     />
   );
 };
-
-export const Invalid = () => {
-  return (
-    <Toggle
-      type="checkbox"
-      title="Companies"
-      helpText="Please don't select Microsoft"
-      invalid
-      selected={[options[1]]}
-      options={options}
-      onChange={(selected) => console.log(selected)}
-    />
-  );
-};
-
-export const Disabled = () => {
-  return (
-    <>
-      <Toggle
-        onChange={(selected) => console.log(selected)}
-        checked={false}
-        type="checkbox"
-        label="Select all companies"
-        indeterminate={true}
-        disabled
-      />
-      <Toggle
-        type="checkbox"
-        title="Companies"
-        options={options}
-        selected={[options[0]]}
-        onChange={(selected) => console.log(selected)}
-        disabled
-      />
-    </>
-  );
-}
 
 export const SelectedDefault = () => {
   return (

--- a/packages/toggle/stories/Checkbox.stories.tsx
+++ b/packages/toggle/stories/Checkbox.stories.tsx
@@ -181,6 +181,29 @@ export const Invalid = () => {
   );
 };
 
+export const Disabled = () => {
+  return (
+    <>
+      <Toggle
+        onChange={(selected) => console.log(selected)}
+        checked={false}
+        type="checkbox"
+        label="Select all companies"
+        indeterminate={true}
+        disabled
+      />
+      <Toggle
+        type="checkbox"
+        title="Companies"
+        options={options}
+        selected={[options[0]]}
+        onChange={(selected) => console.log(selected)}
+        disabled
+      />
+    </>
+  );
+}
+
 export const SelectedDefault = () => {
   return (
     <Toggle

--- a/packages/toggle/stories/Radio.stories.tsx
+++ b/packages/toggle/stories/Radio.stories.tsx
@@ -69,6 +69,20 @@ export const Invalid = () => {
   );
 };
 
+export const Disabled = () => {
+  return (
+    <Toggle
+      type="radio"
+      title="Favorite color"
+      helpText="No way you like blue"
+      disabled
+      selected={[options[1]]}
+      options={options}
+      onChange={(selected) => console.log(selected)}
+    />
+  );
+};
+
 export const SelectedDefaultControlled = () => {
   return (
     <Toggle

--- a/packages/toggle/stories/RadioButtons.stories.tsx
+++ b/packages/toggle/stories/RadioButtons.stories.tsx
@@ -35,6 +35,7 @@ export const Small = () => {
   return (
     <Toggle
       type="radio-button"
+      title="Favorite color"
       small
       options={options}
       onChange={(selected) => console.log(selected)}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: 1.0.2
     version: 1.0.2
   '@warp-ds/css':
-    specifier: 1.8.4-next.3
-    version: 1.8.4-next.3
+    specifier: 1.8.4
+    version: 1.8.4
   '@warp-ds/icons':
     specifier: 2.0.0
     version: 2.0.0
@@ -6288,8 +6288,8 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/css@1.8.4-next.3:
-    resolution: {integrity: sha512-QGyp+MMf6/8MEgAxQSgP4X9huofVVZr9+mFcXJK4/qRxnu7rmhEIa6Vbgb7uKkdFi00gJgs1x4iGWOJgOr/6dQ==}
+  /@warp-ds/css@1.8.4:
+    resolution: {integrity: sha512-SGX3bORF13I20XzCg4Ab0FlUe7Yj4XUH1/klu+NeCVrIWymPhExgFTbFJrs+9RvTKh81d4/IFiyiqdHSpRG6iw==}
     dependencies:
       '@warp-ds/tokenizer': 0.0.4
       '@warp-ds/uno': 1.9.0
@@ -6305,7 +6305,7 @@ packages:
     resolution: {integrity: sha512-D4qIUQdY0Tp23OpeR6P9T5QXpsr9crN/FusHWN+975Yk5WoWZOMAf7SVyvgFKV0uq5s70I3qlZqjT51khMwPNQ==}
     dependencies:
       glob: 10.3.10
-      yaml: 2.3.4
+      yaml: 2.4.1
     dev: false
 
   /@warp-ds/uno@1.9.0:
@@ -15783,9 +15783,10 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
-  /yaml@2.3.4:
-    resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}
+  /yaml@2.4.1:
+    resolution: {integrity: sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==}
     engines: {node: '>= 14'}
+    hasBin: true
     dev: false
 
   /yargs-parser@18.1.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,14 +15,14 @@ dependencies:
     specifier: 1.0.2
     version: 1.0.2
   '@warp-ds/css':
-    specifier: 1.8.3
-    version: 1.8.3
+    specifier: 1.8.4-next.3
+    version: 1.8.4-next.3
   '@warp-ds/icons':
     specifier: 2.0.0
     version: 2.0.0
   '@warp-ds/uno':
-    specifier: 1.8.1
-    version: 1.8.1
+    specifier: 1.9.0
+    version: 1.9.0
   react-focus-lock:
     specifier: 2.9.7
     version: 2.9.7(@types/react@18.2.55)(react@18.2.0)
@@ -6288,11 +6288,11 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/css@1.8.3:
-    resolution: {integrity: sha512-SFG9gmnMv0POtCb9HHp73Gq6Y7eZeoWZDdXhB8tBY71nMRLp45a7tvu5q28OEGIlNF44PGLmRoF2YHbfq+jThg==}
+  /@warp-ds/css@1.8.4-next.3:
+    resolution: {integrity: sha512-QGyp+MMf6/8MEgAxQSgP4X9huofVVZr9+mFcXJK4/qRxnu7rmhEIa6Vbgb7uKkdFi00gJgs1x4iGWOJgOr/6dQ==}
     dependencies:
       '@warp-ds/tokenizer': 0.0.4
-      '@warp-ds/uno': 1.8.1
+      '@warp-ds/uno': 1.9.0
     dev: false
 
   /@warp-ds/icons@2.0.0:
@@ -6308,8 +6308,8 @@ packages:
       yaml: 2.3.4
     dev: false
 
-  /@warp-ds/uno@1.8.1:
-    resolution: {integrity: sha512-khmp3D4MiKOzQ4gHVGHDOPuKsefr7J1Tim62lZjuDZba3t9Mjx2Wd5InfgL5eY3uqV6JTLZHxlPfh9TkhcS8vg==}
+  /@warp-ds/uno@1.9.0:
+    resolution: {integrity: sha512-DVL43/FHdSmOWgKtORsWDKM8WDOZLQHE6cCLYMxkLgJaYMcJGzZ3NrPPV8nwr3g3CL9RF5ySjp5aEKC+ax40Rg==}
     dependencies:
       '@unocss/core': 0.58.5
       '@unocss/preset-mini': 0.58.5

--- a/tests/components/ToggleTest.tsx
+++ b/tests/components/ToggleTest.tsx
@@ -1,0 +1,357 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { toggle as ccToggle, label as ccLabel } from '@warp-ds/css/component-classes';
+
+import { Toggle } from '../../packages/toggle/src/index.js';
+
+const classesToSelectors = (classes: string) => classes.split(' ').map((c) => {
+  // some classes may contain brackets for passing arbitrary values, so we need to escape them
+  const withEscapedBrackets = c.replace(/\[/g, '\\[').replace(/\]/g, '\\]');
+  return `.${withEscapedBrackets}`
+}).join('');
+
+const onChangeFunction = vi.fn();
+
+
+// Checkbox
+describe('Toggle checkbox component', () => {
+  beforeEach(() => {
+    render(
+      <Toggle
+        onChange={onChangeFunction}
+        checked
+        type="checkbox"
+        label="Toggle X"
+      />
+    );
+  })
+  
+  afterEach(() => {
+    vi.resetAllMocks();
+  })
+
+  it('renders', () => {
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+  });
+
+  it('renders a label', () => {
+    const label = screen.getByText('Toggle X');
+    expect(label).toBeInTheDocument();
+  });
+
+  it('calls on change function on click', () => {
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(onChangeFunction).toHaveBeenCalledTimes(1);
+    expect(onChangeFunction).toHaveBeenCalledWith(false);
+  });
+});
+
+it('renders checkbox with title', () => {
+  render(
+    <Toggle
+      type="checkbox"
+      title="Favorite color"
+      onChange={(selected) => onChangeFunction(selected)}
+      label="Toggle X"
+    />
+  );
+  expect(screen.getByText('Favorite color')).toBeInTheDocument();
+});
+
+it('renders checkbox with optional', () => {
+  render(
+    <Toggle
+      optional
+      type="checkbox"
+      title="Favorite color"
+      onChange={(selected) => onChangeFunction(selected)}
+      label="Toggle X"
+    />
+  );
+  expect(screen.getByText('Favorite color')).toHaveTextContent('Favorite color(optional)');
+});
+
+it('renders checkbox with help text', () => {
+  render(
+    <Toggle
+      type="checkbox"
+      title="Favorite color"
+      onChange={(selected) => onChangeFunction(selected)}
+      helpText="Choose your favorite color"
+      label="Toggle X"
+    />
+  );
+  expect(screen.getByText('Choose your favorite color')).toBeInTheDocument();
+});
+
+it('renders checkbox with invalid', () => {
+  render(
+    <Toggle
+      type="checkbox"
+      title="Favorite color"
+      onChange={(selected) => onChangeFunction(selected)}
+      invalid
+      label="Toggle X"
+    />
+  );
+  expect(screen.getByText('Favorite color')).toHaveClass(ccLabel.labelInvalid);
+  expect(screen.getByText('Toggle X')).toHaveClass(ccToggle.checkboxInvalid);
+});
+
+it('renders checkbox with indeterminate', () => {
+  render(
+    <Toggle
+      type="checkbox"
+      title="Favorite color"
+      onChange={(selected) => onChangeFunction(selected)}
+      indeterminate
+      label="Toggle X"
+    />
+  );
+  expect(screen.getByText('Toggle X')).toHaveClass(ccToggle.indeterminate);
+});
+
+it('renders checkbox with no visible label', () => {
+  render(
+    <Toggle
+      type="checkbox"
+      label="Favorite color"
+      onChange={(selected) => onChangeFunction(selected)}
+      noVisibleLabel
+    />
+  );
+  expect(screen.getByText('Favorite color')).toHaveClass(ccToggle.a11y);
+});
+
+it('renders checkbox with disabled', () => {
+  render(
+    <Toggle
+      type="checkbox"
+      label="Favorite color"
+      onChange={(selected) => onChangeFunction(selected)}
+      disabled
+    />
+  );
+  expect(screen.getByRole('checkbox')).toBeDisabled();
+});
+
+// Radio
+describe('Toggle radio component', () => {
+    beforeEach(() => {
+        render(<Toggle
+            onChange={onChangeFunction}
+            checked={false}
+            type="radio"
+            label="Toggle X"
+          />);
+    })
+    
+    afterEach(() => {
+        vi.resetAllMocks();
+    })
+
+    it('renders', () => {
+        expect(screen.getByRole('radio')).toBeInTheDocument();
+    });
+
+    it('renders a label', () => {
+        const label = screen.getByText('Toggle X');
+        expect(label).toBeInTheDocument();
+    });
+
+    it('calls on change function on click', () => {
+        fireEvent.click(screen.getByRole('radio'));
+
+        expect(onChangeFunction).toHaveBeenCalledTimes(1);
+        expect(onChangeFunction).toHaveBeenCalledWith(true);
+    });
+});
+
+it('renders radio with title', () => {
+  render(
+    <Toggle
+      type="radio"
+      title="Favorite color"
+      onChange={(selected) => onChangeFunction(selected)}
+      label="Toggle X"
+    />
+  );
+  expect(screen.getByText('Favorite color')).toBeInTheDocument();
+});
+
+it('renders radio with optional', () => {
+  render(
+    <Toggle
+      optional
+      type="radio"
+      title="Favorite color"
+      onChange={(selected) => onChangeFunction(selected)}
+      label="Toggle X"
+    />
+  );
+  expect(screen.getByText('Favorite color')).toHaveTextContent('Favorite color(optional)');
+});
+
+it('renders radio with help text', () => {
+  render(
+    <Toggle
+      type="radio"
+      title="Favorite color"
+      onChange={(selected) => onChangeFunction(selected)}
+      helpText="Choose your favorite color"
+      label="Toggle X"
+    />
+  );
+  expect(screen.getByText('Choose your favorite color')).toBeInTheDocument();
+});
+
+it('renders radio with invalid', () => {
+  render(
+    <Toggle
+      type="radio"
+      title="Favorite color"
+      onChange={(selected) => onChangeFunction(selected)}
+      invalid
+      label="Toggle X"
+    />
+  );
+  expect(screen.getByText('Favorite color')).toHaveClass(ccLabel.labelInvalid);
+  expect(screen.getByText('Toggle X')).toHaveClass(ccToggle.radioInvalid);
+});
+
+it('renders radio with no visible label', () => {
+  render(
+    <Toggle
+      type="radio"
+      label="Favorite color"
+      onChange={(selected) => onChangeFunction(selected)}
+      noVisibleLabel
+    />
+  );
+  expect(screen.getByText('Favorite color')).toHaveClass(ccToggle.a11y);
+});
+
+it('renders radio with disabled', () => {
+  render(
+    <Toggle
+      type="radio"
+      label="Favorite color"
+      onChange={(selected) => onChangeFunction(selected)}
+      disabled
+    />
+  );
+  expect(screen.getByRole('radio')).toBeDisabled();
+});
+
+const options = [
+  { label: 'Red', value: 'red' },
+  { label: 'Blue', value: 'blue' },
+  { label: 'Green', value: 'green' },
+];
+
+// Radio button
+describe('Toggle radio button component', () => {
+  beforeEach(() => {
+    render(
+      <Toggle
+        type="radio-button"
+        options={options}
+        onChange={(selected) => onChangeFunction(selected)}
+        label="Toggle X"
+      />
+    );
+  })
+  
+  afterEach(() => {
+      vi.resetAllMocks();
+  })
+
+  it('renders', () => {
+    expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+  });
+
+  it('renders 3 radio input', () => {
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+  });
+
+  it('renders correct labels', () => {
+    expect(() => screen.getByText('Toggle X')).toThrow();
+    expect(screen.getAllByRole('radio')[0].nextElementSibling?.textContent).toBe('Red');
+    expect(screen.getAllByRole('radio')[1].nextElementSibling?.textContent).toBe('Blue');
+    expect(screen.getAllByRole('radio')[2].nextElementSibling?.textContent).toBe('Green');
+  });
+
+  it('calls on change function on click', () => {
+    fireEvent.click(screen.getAllByRole('radio')[0]);
+
+    expect(onChangeFunction).toHaveBeenCalledTimes(1);
+    expect(onChangeFunction).toHaveBeenCalledWith(options[0]);
+  });
+});
+
+it('renders radio button with equal width', () => {
+  const { container } = render(
+    <Toggle
+      type="radio-button"
+      equalWidth
+      options={options}
+      onChange={(selected) => onChangeFunction(selected)}
+    />
+  );
+  const justifiedRadioButtonClasses = classesToSelectors(ccToggle.radioButtonsGroupJustified);
+  expect(container.querySelector(justifiedRadioButtonClasses)).toBeInTheDocument();
+});
+
+it('renders radio button with small size', () => {
+  const { container } = render(
+    <Toggle
+      type="radio-button"
+      small
+      options={options}
+      onChange={(selected) => onChangeFunction(selected)}
+    />
+  );
+  const smallRadioButtonClasses = classesToSelectors(ccToggle.radioButtonsSmall);
+
+  expect(container.querySelector(smallRadioButtonClasses)).toBeInTheDocument();
+});
+
+it('renders radio button with title', () => {
+  render(
+    <Toggle
+      type="radio-button"
+      title="Favorite color"
+      options={options}
+      onChange={(selected) => onChangeFunction(selected)}
+    />
+  );
+  expect(screen.getByText('Favorite color')).toBeInTheDocument();
+});
+
+it('renders radio button with optional', () => {
+  render(
+    <Toggle
+      optional
+      type="radio-button"
+      title="Favorite color"
+      options={options}
+      onChange={(selected) => onChangeFunction(selected)}
+    />
+  );
+  expect(screen.getByText('Favorite color')).toHaveTextContent('Favorite color(optional)');
+});
+
+it('renders radio button with help text', () => {
+  render(
+    <Toggle
+      type="radio-button"
+      title="Favorite color"
+      options={options}
+      onChange={(selected) => onChangeFunction(selected)}
+      helpText="Choose your favorite color"
+    />
+  );
+  expect(screen.getByText('Choose your favorite color')).toBeInTheDocument();
+});

--- a/tests/components/ToggleTest.tsx
+++ b/tests/components/ToggleTest.tsx
@@ -100,6 +100,18 @@ it('renders checkbox with invalid', () => {
   expect(screen.getByText('Toggle X')).toHaveClass(ccToggle.checkboxInvalid);
 });
 
+it('renders checkbox with disabled', () => {
+  render(
+    <Toggle
+      type="checkbox"
+      label="Favorite color"
+      onChange={(selected) => onChangeFunction(selected)}
+      disabled
+    />
+  );
+  expect(screen.getByRole('checkbox')).toBeDisabled();
+});
+
 it('renders checkbox with indeterminate', () => {
   render(
     <Toggle
@@ -113,6 +125,34 @@ it('renders checkbox with indeterminate', () => {
   expect(screen.getByText('Toggle X')).toHaveClass(ccToggle.indeterminate);
 });
 
+it('renders checkbox with indeterminate invalid', () => {
+  render(
+    <Toggle
+      type="checkbox"
+      title="Favorite color"
+      onChange={(selected) => onChangeFunction(selected)}
+      indeterminate
+      invalid
+      label="Toggle X"
+    />
+  );
+  expect(screen.getByText('Toggle X')).toHaveClass(ccToggle.indeterminateInvalid);
+});
+
+it('renders checkbox with indeterminate disabled', () => {
+  render(
+    <Toggle
+      type="checkbox"
+      title="Favorite color"
+      onChange={(selected) => onChangeFunction(selected)}
+      indeterminate
+      disabled
+      label="Toggle X"
+    />
+  );
+  expect(screen.getByText('Toggle X')).toHaveClass(ccToggle.indeterminateDisabled);
+});
+
 it('renders checkbox with no visible label', () => {
   render(
     <Toggle
@@ -123,18 +163,6 @@ it('renders checkbox with no visible label', () => {
     />
   );
   expect(screen.getByText('Favorite color')).toHaveClass(ccToggle.a11y);
-});
-
-it('renders checkbox with disabled', () => {
-  render(
-    <Toggle
-      type="checkbox"
-      label="Favorite color"
-      onChange={(selected) => onChangeFunction(selected)}
-      disabled
-    />
-  );
-  expect(screen.getByRole('checkbox')).toBeDisabled();
 });
 
 // Radio


### PR DESCRIPTION
Depends on
-  https://github.com/warp-ds/css/pull/176

## Description
Fixes [WARP-506](https://nmp-jira.atlassian.net/browse/WARP-506)

With these changes our Toggle component will no longer apply classes that control the same CSS property on one element (`input` or `label`). As a result, Toggle should have correct style in different states.
As an addition, `disabled` state handling was restored. This way we align the component with Vue Toggle and the design.

### Checkbox
| Finn    | Tori |
| -------- | ------- |
| <img width="187" alt="Screenshot of checkboxes in indeterminate, checked and unchecked state (Finn theme)" src="https://github.com/warp-ds/css/assets/41303231/42bf1752-372e-48df-a2bc-fa5be46549cd">  | <img width="195" alt="Screenshot of checkboxes in indeterminate, checked and unchecked state (Tori theme)" src="https://github.com/warp-ds/css/assets/41303231/5e93f37c-a802-48c2-9667-6725cd11dd50">  |

### Checkbox invalid
| Finn    | Tori |
| -------- | ------- |
| <img width="179" alt="Screenshot of invalid checkboxes in indeterminate, checked, hover and unchecked state (Finn theme)" src="https://github.com/warp-ds/css/assets/41303231/28e0aa8e-e621-4985-a6c2-92c30e421c58"> | <img width="198" alt="Screenshot of invalid checkboxes in indeterminate, checked, hover and unchecked state (Tori theme)" src="https://github.com/warp-ds/css/assets/41303231/6251a471-d8a6-4e53-9e3e-10047614bdb5"> |


### Checkbox disabled
| Finn    | Tori |
| -------- | ------- |
| <img width="197" alt="Screenshot of invalid checkboxes in indeterminate, checked and unchecked state (Finn theme)" src="https://github.com/warp-ds/css/assets/41303231/53230ce2-0f49-4493-9967-3b09c9f4e2aa"> | <img width="192" alt="Screenshot of disabled checkboxes in indeterminate, checked and unchecked state (Tori theme)" src="https://github.com/warp-ds/css/assets/41303231/18362b77-5450-483b-90c3-b1c4d87bec64">  |

### Radio
| Finn    | Tori |
| -------- | ------- |
| <img width="195" alt="Screenshot of radios in checked, hover and unchecked state (Finn theme)" src="https://github.com/warp-ds/css/assets/41303231/1f710d60-1898-4fe1-ab7d-6b03db81ccc7"> | <img width="211" alt="Screenshot of radios in checked, hover and unchecked state (Tori theme)" src="https://github.com/warp-ds/css/assets/41303231/08c57692-8928-43d1-ac02-bfa297153a92"> |

### Radio invalid
| Finn    | Tori |
| -------- | ------- |
| <img width="130" alt="Screenshot of invalid radios in checked, hover and unchecked state (Finn theme)" src="https://github.com/warp-ds/css/assets/41303231/569940be-aee1-46ea-8bf4-6f743b17ddd1"> | <img width="140" alt="Screenshot of invalid radios in checked, hover and unchecked state (Tori theme)" src="https://github.com/warp-ds/css/assets/41303231/c45f03fd-fc24-47e6-8405-5784a16c7b6d"> |

### Radio disabled
| Finn    | Tori |
| -------- | ------- |
| <img width="120" alt="Screenshot of disabled radios in checked and unchecked state (Finn theme)" src="https://github.com/warp-ds/css/assets/41303231/17200d72-8380-4392-978d-288d1e15e0f0"> | <img width="134" alt="Screenshot of invalid radios in checked and unchecked state (Tori theme)" src="https://github.com/warp-ds/css/assets/41303231/f91359fc-21b5-45a4-a407-ed59acc0ffcf"> |

### Radio button
| Finn    | Tori |
| -------- | ------- |
| <img width="189" alt="Screenshot of a radio button group in checked, hover and unchecked state (Finn theme)" src="https://github.com/warp-ds/css/assets/41303231/30cc5617-20aa-4879-858d-1bc3ee71cbe1"> | <img width="187" alt="Screenshot of a radio button group in checked, hover and unchecked state (Tori theme)" src="https://github.com/warp-ds/css/assets/41303231/a3c2237e-691a-4597-97f7-532f865c8bd2"> |

### Radio button small
| Finn    | Tori |
| -------- | ------- |
| <img width="151" alt="Screenshot of a small radio button group in checked, hover and unchecked state" src="https://github.com/warp-ds/css/assets/41303231/bd83b394-151b-4cf4-bd1b-7908ea614742"> | <img width="146" alt="Screenshot of a radio button group in checked, hover and unchecked state" src="https://github.com/warp-ds/css/assets/41303231/aff395a4-df42-4dbc-be35-e0334c162e94"> |
