### PR TITLE
fix(dead-toggle): add 'name' prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@chbphone55/classnames": "2.0.0",
     "@lingui/core": "4.7.0",
     "@warp-ds/core": "1.0.2",
-    "@warp-ds/css": "1.8.4",
+    "@warp-ds/css": "1.8.5",
     "@warp-ds/icons": "2.0.0",
     "@warp-ds/uno": "1.9.0",
     "react-focus-lock": "2.9.7",

--- a/packages/_helpers/dead-toggle.tsx
+++ b/packages/_helpers/dead-toggle.tsx
@@ -33,6 +33,11 @@ export interface DeadToggleProps {
    * Additional classnames to the toggle label
    */
   labelClassName?: string;
+
+  /**
+   * Name of the toggle input
+   */
+  name?: string;
 }
 
 export function DeadToggle(props: DeadToggleProps) {
@@ -50,7 +55,7 @@ export function DeadToggle(props: DeadToggleProps) {
           [ccDeadToggle.labelRadio]: props.radio,
           [ccDeadToggle.labelCheckbox]: props.checkbox,
         })}
-        name="dead-toggle"
+        name={props.name ? `${props.name}:dead-toggle` : "dead-toggle"}
         controlled={true}
         onChange={() => undefined}
         value={props.value}

--- a/packages/card/stories/Card.stories.tsx
+++ b/packages/card/stories/Card.stories.tsx
@@ -330,3 +330,57 @@ export const DeadToggleInCard = () => {
     </div>
   );
 };
+
+const ClickableCardWithDeadToggle = ({
+  id,
+  isSelected,
+  setSelected,
+  name,
+}: {
+  id: number;
+  isSelected: boolean;
+  setSelected: (value: React.SetStateAction<number | null>) => void;
+  name: string;
+}) => {
+  return (
+      <Card className={`w-full flex items-center py-14 px-14 gap-14 my-12`} selected={isSelected}>
+          <DeadToggle radio checked={isSelected} name={name} />
+          <Clickable radio name={name} onClick={() => setSelected(id)} autofocus={true}>
+              <h2 className="h4 mb-0">{id}</h2>
+          </Clickable>
+      </Card>
+  );
+};
+
+export const MultipleDeadToggleGroups = () => {
+  const [selectedRadio, setSelectedRadio] = useState<number | null>(null);
+  const [secondSelectedRadio, setSecondSelectedRadio] = useState<number | null>(null);
+  return (
+      <div>
+          <fieldset key={1} className="mb-12" role="radiogroup">
+              Radio group 1
+              {[0, 1, 2].map((i) => (
+                  <ClickableCardWithDeadToggle
+                      key={i}
+                      id={i}
+                      isSelected={selectedRadio === i}
+                      setSelected={(x) => setSelectedRadio(x)}
+                      name="first-group"
+                  />
+              ))}
+          </fieldset>
+          <fieldset key={2} role="radiogroup">
+              Radio group 2
+              {[3, 4, 5].map((i) => (
+                  <ClickableCardWithDeadToggle
+                      key={i}
+                      id={i}
+                      isSelected={secondSelectedRadio === i}
+                      setSelected={(x) => setSecondSelectedRadio(x)}
+                      name="second-group"
+                  />
+              ))}
+          </fieldset>
+      </div>
+  );
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: 1.0.2
     version: 1.0.2
   '@warp-ds/css':
-    specifier: 1.8.4
-    version: 1.8.4
+    specifier: 1.8.5
+    version: 1.8.5
   '@warp-ds/icons':
     specifier: 2.0.0
     version: 2.0.0
@@ -6288,8 +6288,8 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/css@1.8.4:
-    resolution: {integrity: sha512-SGX3bORF13I20XzCg4Ab0FlUe7Yj4XUH1/klu+NeCVrIWymPhExgFTbFJrs+9RvTKh81d4/IFiyiqdHSpRG6iw==}
+  /@warp-ds/css@1.8.5:
+    resolution: {integrity: sha512-vh0Nv0aSPH6ymBqhrvbwvEd3iaYuRmuiJOUAbD/md4x9uDXqQpdhtuTCw4eDkNm9NswaRso2iQUl5oeL12t3/w==}
     dependencies:
       '@warp-ds/tokenizer': 0.0.4
       '@warp-ds/uno': 1.9.0


### PR DESCRIPTION
## Description
Fixes [WARP-514](https://nmp-jira.atlassian.net/browse/WARP-514)

Fixes behaviour of a checked `DeadToggle` of type `radio` when multiple groups of `DeadToggles` are rendered on the same page.

| Before | After |
| ----- | ----- |
| <img width="192" alt="Screenshot of 2 groups of cards with radio dead-toggles, both groups have 1 selected card, but in the first group the radio element is not checked" src="https://github.com/warp-ds/react/assets/41303231/a29dee3c-f536-4d2f-a17e-8fa4b9295dc9"> | <img width="195" alt="Screenshot of 2 groups of cards with radio dead-toggles, both groups have 1 selected card, and both radio elements are checked" src="https://github.com/warp-ds/react/assets/41303231/8e8c3e1f-03c2-4943-8b94-5fb5b5e4f8a9">
