### PR TITLE
fix(forms): use correct colors in label and error text

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@chbphone55/classnames": "2.0.0",
     "@lingui/core": "4.7.0",
     "@warp-ds/core": "1.0.2",
-    "@warp-ds/css": "1.8.5",
+    "@warp-ds/css": "1.9.1",
     "@warp-ds/icons": "2.0.0",
     "@warp-ds/uno": "1.9.0",
     "react-focus-lock": "2.9.7",

--- a/packages/select/src/component.tsx
+++ b/packages/select/src/component.tsx
@@ -67,7 +67,8 @@ const setup = (props) => {
     }),
     helpTextClasses: classNames({
       [ccHelpText.helpText]: true,
-      [ccHelpText.helpTextInvalid]: invalid
+      [ccHelpText.helpTextColor]: !invalid,
+      [ccHelpText.helpTextColorInvalid]: invalid
     }),
     labelClasses: classNames({
       [ccLabel.label]: true,

--- a/packages/select/src/component.tsx
+++ b/packages/select/src/component.tsx
@@ -70,10 +70,6 @@ const setup = (props) => {
       [ccHelpText.helpTextColor]: !invalid,
       [ccHelpText.helpTextColorInvalid]: invalid
     }),
-    labelClasses: classNames({
-      [ccLabel.label]: true,
-      [ccLabel.labelInvalid]: invalid
-    }),
     chevronClasses: classNames({
       [ccSelect.chevron]: true,
       [ccSelect.chevronDisabled]: disabled,
@@ -83,13 +79,13 @@ const setup = (props) => {
 
 function Select(props: SelectProps, ref: React.Ref<HTMLSelectElement>) {
   const id = useId(props.id);
-  const { attrs, wrapperClasses, selectClasses, selectWrapperClasses, helpTextClasses, labelClasses, chevronClasses } = setup({ ...props, id });
+  const { attrs, wrapperClasses, selectClasses, selectWrapperClasses, helpTextClasses, chevronClasses } = setup({ ...props, id });
   const { div, label, select, help, optional } = attrs;
 
   return (
     <div className={wrapperClasses} {...div}>
       {label.children && (
-        <label htmlFor={label.htmlFor} className={labelClasses}>
+        <label htmlFor={label.htmlFor} className={ccLabel.label}>
           {label.children}
           {optional && (
             <span className={ccLabel.optional}>

--- a/packages/select/stories/Select.stories.tsx
+++ b/packages/select/stories/Select.stories.tsx
@@ -40,6 +40,7 @@ export const invalid = () => {
   return (
   <div className="flex flex-col space-y-32">
     <WarpSelect
+      label="Berries"
       invalid={!valid}
       hint={!valid ? "Wrong choice" : ""}
       onChange={handleOnChange}

--- a/packages/textarea/src/component.tsx
+++ b/packages/textarea/src/component.tsx
@@ -103,7 +103,8 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
         {helpText && <div 
           className={classNames({
             [ccHelpText.helpText]: true,
-            [ccHelpText.helpTextInvalid]: isInvalid
+            [ccHelpText.helpTextColor]: !isInvalid,
+            [ccHelpText.helpTextColorInvalid]: isInvalid
           })}
           id={helpId}
           >{helpText}</div>}

--- a/packages/textarea/src/component.tsx
+++ b/packages/textarea/src/component.tsx
@@ -53,10 +53,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
         style={style}
       >
         {label && (
-          <label htmlFor={id} className={classNames({
-            [ccLabel.label]: true,
-            [ccLabel.labelInvalid]: isInvalid
-          })} >
+          <label htmlFor={id} className={ccLabel.label} >
             {label}
             {optional && (
               <span className={ccLabel.optional}>

--- a/packages/textarea/stories/TextArea.stories.tsx
+++ b/packages/textarea/stories/TextArea.stories.tsx
@@ -47,12 +47,7 @@ export const autoFocus = () => <TextArea label="Description" autoFocus />;
 
 export const disabled = () => <TextArea label="Description" disabled />;
 
-export const invalid = () => (
-  <div className="flex flex-col space-y-48">
-    <TextArea label="Description" invalid />
-    <TextArea label="Description" invalid helpText="Invalid text" />
-  </div>
-);
+export const invalid = () => <TextArea label="Description" invalid helpText="Invalid text" />;
 
 export const minimumRows3 = () => (
   <TextArea label="Description" minimumRows={3} />

--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -54,10 +54,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
             `}
           </style>
           {label && (
-            <label htmlFor={id} className={classNames({
-              [ccLabel.label]: true,
-              [ccLabel.labelInvalid]: isInvalid
-            })} >
+            <label htmlFor={id} className={ccLabel.label} >
               {label}
               {optional && (
                 <span className={ccLabel.optional}>

--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -100,7 +100,8 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
           {helpText && (
             <div className={classNames({
               [ccHelpText.helpText]: true,
-              [ccHelpText.helpTextInvalid]: isInvalid
+              [ccHelpText.helpTextColor]: !isInvalid,
+              [ccHelpText.helpTextColorInvalid]: isInvalid
             })} id={helpId}>
               {helpText}
             </div>

--- a/packages/textfield/stories/Textfield.stories.tsx
+++ b/packages/textfield/stories/Textfield.stories.tsx
@@ -92,12 +92,7 @@ export const helpText = () => (
   <TextField helpText="Necessary because of reasons" />
 );
 
-export const invalid = () => (
-  <div className="flex flex-col space-y-48">
-    <TextField invalid />
-    <TextField helpText="Error text" invalid />
-  </div>
-);
+export const invalid = () => <TextField helpText="Error text" invalid />;
 
 export const optional = () => (
   <div className="flex flex-col space-y-48">

--- a/packages/toggle/src/component.tsx
+++ b/packages/toggle/src/component.tsx
@@ -43,7 +43,8 @@ function HelpText({ isInvalid, helpId, helpText }: any) {
       id={helpId}
       className={classNames({
         [ccHelpText.helpText]: true,
-        [ccHelpText.helpTextInvalid]: isInvalid
+        [ccHelpText.helpTextColor]: !isInvalid,
+        [ccHelpText.helpTextColorInvalid]: isInvalid
       })}
     >
       {helpText}

--- a/packages/toggle/src/component.tsx
+++ b/packages/toggle/src/component.tsx
@@ -10,16 +10,13 @@ import { messages as enMessages} from './locales/en/messages.mjs';
 import { messages as fiMessages} from './locales/fi/messages.mjs';
 import { activateI18n } from '../../i18n.js';
 
-function Title({ id, isInvalid, title, optional }) {
+function Title({ id, title, optional }) {
   activateI18n(enMessages, nbMessages, fiMessages);
 
   return (
     <legend
       id={`${id}__title`}
-      className={classNames({
-        [ccLabel.label]: true,
-        [ccLabel.labelInvalid]: isInvalid,
-      })}
+      className={ccLabel.label}
     >
       {title}
       {optional && (
@@ -108,7 +105,6 @@ export function Toggle(props: ToggleProps) {
         <Title
           id={id}
           title={props.title}
-          isInvalid={isInvalid}
           optional={props.optional}
         />
       )}

--- a/packages/toggle/stories/Checkbox.stories.tsx
+++ b/packages/toggle/stories/Checkbox.stories.tsx
@@ -112,6 +112,7 @@ export const IndeterminateState = ({
         selected={selectedOptions}
         onChange={handleSelect}
         invalid={isInvalid}
+        helpText={isInvalid ? 'This is an error message' : undefined}
         disabled={isDisabled}
       />
     </>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: 1.0.2
     version: 1.0.2
   '@warp-ds/css':
-    specifier: 1.8.5
-    version: 1.8.5
+    specifier: 1.9.1
+    version: 1.9.1
   '@warp-ds/icons':
     specifier: 2.0.0
     version: 2.0.0
@@ -6288,8 +6288,8 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/css@1.8.5:
-    resolution: {integrity: sha512-vh0Nv0aSPH6ymBqhrvbwvEd3iaYuRmuiJOUAbD/md4x9uDXqQpdhtuTCw4eDkNm9NswaRso2iQUl5oeL12t3/w==}
+  /@warp-ds/css@1.9.1:
+    resolution: {integrity: sha512-AlfEwB0ernCxA/TccSElR2sJcTP6crEJthBHBvJyqi+TpUFE8R/8oCdw2Lh4rDCG3b86dtfthi1hzp9JN0LK9w==}
     dependencies:
       '@warp-ds/tokenizer': 0.0.4
       '@warp-ds/uno': 1.9.0

--- a/tests/components/ToggleTest.tsx
+++ b/tests/components/ToggleTest.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { toggle as ccToggle, label as ccLabel } from '@warp-ds/css/component-classes';
+import { toggle as ccToggle, label as ccLabel, helpText as ccHelpText } from '@warp-ds/css/component-classes';
 
 import { Toggle } from '../../packages/toggle/src/index.js';
 
@@ -94,10 +94,11 @@ it('renders checkbox with invalid', () => {
       onChange={(selected) => onChangeFunction(selected)}
       invalid
       label="Toggle X"
+      helpText="This is an error message"
     />
   );
-  expect(screen.getByText('Favorite color')).toHaveClass(ccLabel.labelInvalid);
-  expect(screen.getByText('Toggle X')).toHaveClass(ccToggle.checkboxInvalid);
+  expect(screen.getByText('Favorite color')).toHaveClass(ccLabel.label);
+  expect(screen.getByText('This is an error message')).toHaveClass(ccHelpText.helpTextColorInvalid);
 });
 
 it('renders checkbox with disabled', () => {
@@ -243,10 +244,11 @@ it('renders radio with invalid', () => {
       onChange={(selected) => onChangeFunction(selected)}
       invalid
       label="Toggle X"
+      helpText="This is an error message"
     />
   );
-  expect(screen.getByText('Favorite color')).toHaveClass(ccLabel.labelInvalid);
-  expect(screen.getByText('Toggle X')).toHaveClass(ccToggle.radioInvalid);
+  expect(screen.getByText('Favorite color')).toHaveClass(ccLabel.label);
+  expect(screen.getByText('This is an error message')).toHaveClass(ccHelpText.helpTextColorInvalid);
 });
 
 it('renders radio with no visible label', () => {


### PR DESCRIPTION
## Description
Fixes [WARP-515](https://nmp-jira.atlassian.net/browse/WARP-515)

Changes based on the [Figma component library](https://www.figma.com/file/oHBCzDdJxHQ6fmFLYWUltf/Warp---Components-2.0?type=design&node-id=954-37013&mode=design&t=NPcTtpnw8dXLMG36-0):
- label color doesn't change when input is invalid
- label optional should have subtle text color (the other changes to label optional should be handled in a separate task)
- helpText color should be negative when input is invalid

<img width="164" alt="Screenshot of Radio group component with label in dark grey and help text in red" src="https://github.com/warp-ds/css/assets/41303231/8e721ee5-0a9c-4d81-af23-78fad752eb07">
<img width="240" alt="Screenshot of TextField component with label in dark grey and help text in red" src="https://github.com/warp-ds/css/assets/41303231/535a6a2f-e4ce-4299-9e08-c5710b78b83f">
<img width="240" alt="Screenshot of Textarea component with label in dark grey and help text in red" src="https://github.com/warp-ds/css/assets/41303231/7ce0b9bd-1b8b-42bc-9d9f-9f19b27bc4bd">
<img width="245" alt="Screenshot of Selecta component with label in dark grey and help text in red" src="https://github.com/warp-ds/css/assets/41303231/3f9ad6e7-55be-48bd-acda-b87cbf8174d9">
<img width="242" alt="Screenshot of Select component with optional label in subtle grey" src="https://github.com/warp-ds/css/assets/41303231/524068df-b3f9-4de8-837c-cc6c6fd3be5e">
