### PR TITLE
feat: Add an optional prop to enable nofollow for pagination component

### DIFF
--- a/packages/pagination/src/NextPage.tsx
+++ b/packages/pagination/src/NextPage.tsx
@@ -17,6 +17,9 @@ type NextPageProps = {
   /** The href for the anchor element. */
   href: string;
 
+  /** Enable nofollow rel */
+  noFollow?: boolean;
+
   /** Additional CSS styles for the element. */
   style?: React.CSSProperties;
 
@@ -27,7 +30,7 @@ type NextPageProps = {
 const NextPage = React.forwardRef<
   React.AnchorHTMLAttributes<HTMLAnchorElement>,
   NextPageProps
->(({ className, ...props }, ref) => {
+>(({ className, noFollow, ...props }, ref) => {
   const { currentPage, lastPage } = usePagination();
 
   if (currentPage >= lastPage) {
@@ -54,7 +57,7 @@ const NextPage = React.forwardRef<
       <a
         {...props}
         ref={ref as Ref<HTMLAnchorElement>}
-        rel="next nofollow"
+        rel={`next${noFollow ? ' nofollow' : ''}`}
         className={classNames(className, ccPagination.link, ccPagination.icon)}
       >
         <span className={ccPagination.a11y}>

--- a/packages/pagination/src/Page.tsx
+++ b/packages/pagination/src/Page.tsx
@@ -19,6 +19,9 @@ export type PageProps = {
 
   page?: number;
 
+  /** Enable nofollow rel */
+  noFollow?: boolean;
+
   /** Additional CSS styles for the element. */
   style?: React.CSSProperties;
 
@@ -29,7 +32,7 @@ export type PageProps = {
 const Page = React.forwardRef<
   React.AnchorHTMLAttributes<HTMLAnchorElement>,
   PageProps
->(({ page = 1, className, currentPage, ...props }, ref) => {
+>(({ page = 1, className, currentPage, noFollow, ...props }, ref) => {
 
   const isCurrentPage = page === currentPage;
 
@@ -46,7 +49,7 @@ const Page = React.forwardRef<
       aria-label={ariaLabel}
       {...props}
       ref={ref as Ref<HTMLAnchorElement>}
-      rel="nofollow"
+      rel={`${noFollow ? 'nofollow' : ''}`}
       aria-current={isCurrentPage ? 'page' : undefined}
       className={classNames(className, ccPagination.link, [isCurrentPage ? ccPagination.active : ccPagination.notActive])}
     >

--- a/packages/pagination/src/Pagination.tsx
+++ b/packages/pagination/src/Pagination.tsx
@@ -27,6 +27,9 @@ export type PaginationProps = {
   /** The number of the last page. */
   lastPage: number;
 
+  /** Enable nofollow rel */
+  noFollow?: boolean;
+
   /** Handler that is called with the page number to navigate to. `event.preventDefault` is called for you. Fallbacks to default browser behavior if undefined. */
   onChange?: (page: number) => void;
 
@@ -46,6 +49,7 @@ export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
       createHref,
       className,
       onChange,
+      noFollow,
       ...props
     },
     ref,
@@ -77,16 +81,18 @@ export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
         <PrevPage
           href={createHref(currentPage - 1)}
           onClick={handleClick(currentPage - 1)}
+          noFollow={noFollow}
         />
         <Pages numPages={numPages}>
           {(page) => (
-            <Page href={createHref(page)} onClick={handleClick(page)} />
+            <Page href={createHref(page)} onClick={handleClick(page)} noFollow={noFollow} />
           )}
         </Pages>
         <CurrentPage />
         <NextPage
           href={createHref(currentPage + 1)}
           onClick={handleClick(currentPage + 1)}
+          noFollow={noFollow}
         />
       </PaginationContainer>
     );

--- a/packages/pagination/src/PrevPage.tsx
+++ b/packages/pagination/src/PrevPage.tsx
@@ -19,6 +19,9 @@ type PrevPageProps = {
 
   /** Additional CSS styles for the element. */
   style?: React.CSSProperties;
+  
+  /** Enable nofollow rel */
+  noFollow?: boolean;
 
   /** onClick function */
   onClick: (event: React.UIEvent<HTMLElement>) => void;
@@ -27,7 +30,7 @@ type PrevPageProps = {
 const PrevPage = React.forwardRef<
   React.AnchorHTMLAttributes<HTMLAnchorElement>,
   PrevPageProps
->(({ className, ...props }, ref) => {
+>(({ className, noFollow, ...props }, ref) => {
   const { currentPage } = usePagination();
 
   if (currentPage === 1) {
@@ -56,7 +59,7 @@ const PrevPage = React.forwardRef<
       {...props}
       ref={ref as Ref<HTMLAnchorElement>}
       className={classNames(className, ccPagination.link, ccPagination.icon)}
-      rel="prev nofollow"
+      rel={`prev${noFollow ? ' nofollow' : ''}`}
     >
       <span className={ccPagination.a11y}>
         {ariaLabel},

--- a/packages/pagination/stories/Pagination.stories.tsx
+++ b/packages/pagination/stories/Pagination.stories.tsx
@@ -6,7 +6,7 @@ export default metadata;
 
 const Example = ({ initialPage = 1, lastPage = 30, ...props }) => {
   const [currentPage, setCurrentPage] = React.useState(initialPage);
-
+  
   return (
     <>
       <div style={{ textAlign: 'center', marginTop: '50px' }}>
@@ -29,5 +29,6 @@ export const Normal = () => (
     <Example initialPage={1} lastPage={10} aria-labelledby="pagination-1" />
     <Example initialPage={10} lastPage={20} aria-labelledby="pagination-2" />
     <Example initialPage={30} lastPage={30} aria-labelledby="pagination-3" />
+    <Example initialPage={1} lastPage={10} aria-labelledby="pagination-4" noFollow />
   </>
 );


### PR DESCRIPTION
This will allow teams to decide if they want to have a nofollow rel on pagination component or not. This is an optional prop.