### PR TITLE
fix(tabs): clean up classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@chbphone55/classnames": "2.0.0",
     "@lingui/core": "4.7.0",
     "@warp-ds/core": "1.1.1",
-    "@warp-ds/css": "1.9.6",
+    "@warp-ds/css": "github:warp-ds/css#component-classes-cleanup",
     "@warp-ds/icons": "2.0.0",
     "@warp-ds/uno": "1.12.0",
     "react-focus-lock": "2.9.7",

--- a/packages/tabs/src/component-tab.tsx
+++ b/packages/tabs/src/component-tab.tsx
@@ -8,20 +8,15 @@ import type { TabProps } from './props.js';
 const setup = ({ className, isActive, setActive, ...rest }: any) => ({
   tab: classNames(ccTab.tab, {
     [className]: !!className,
+    [ccTab.tabInactive]: !isActive,
     [ccTab.tabActive]: isActive,
-  }),
-  icon: classNames(ccTab.icon, {
-    [ccTab.iconUnderlinedActive]: isActive,
-  }),
-  content: classNames(ccTab.contentUnderlined, {
-    [ccTab.contentUnderlinedActive]: isActive,
   }),
   attrs: { ...rest },
 });
 
 export function Tab(props: TabProps) {
   const { children, label, setActive = () => {}, name, onClick, isActive } = props;
-  const { tab, icon, content, attrs } = setup(props);
+  const { tab, attrs } = setup(props);
   const { over, ...rest } = attrs;
 
   const handleClick = (e) => {
@@ -40,12 +35,12 @@ export function Tab(props: TabProps) {
       tabIndex={isActive ? 0 : -1}
       className={tab}
       onClick={handleClick}>
-      {!children && <span className={content}>{label}</span>}
+      {!children && <span className={ccTab.contentUnderlined}>{label}</span>}
 
       {children && over && (
         <>
-          <span className={icon}>{children}</span>
-          <span className={content}>{label}</span>
+          <span className={ccTab.icon}>{children}</span>
+          <span className={ccTab.contentUnderlined}>{label}</span>
         </>
       )}
 

--- a/packages/tabs/src/component-tabs.tsx
+++ b/packages/tabs/src/component-tabs.tsx
@@ -11,7 +11,7 @@ const setup = ({ className, children, onClick, active, ...rest }: any, tabsRef, 
     [className]: !!className,
   }),
   div: classNames(ccTabs.tabContainer, {
-    [gridLayout[`cols${children.length}`]]: true,
+    [gridLayout[`cols${children.filter((node) => node).length}`]]: true,
   }),
   wunderbar: classNames(ccTabs.wunderbar),
   attrs: rest,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1(@floating-ui/dom@1.6.5)
       '@warp-ds/css':
-        specifier: 1.9.6
-        version: 1.9.6
+        specifier: github:warp-ds/css#component-classes-cleanup
+        version: https://codeload.github.com/warp-ds/css/tar.gz/625349af0401f74238cb7511262e69064c508710
       '@warp-ds/icons':
         specifier: 2.0.0
         version: 2.0.0
@@ -3071,8 +3071,9 @@ packages:
     peerDependencies:
       '@floating-ui/dom': 1.6.3
 
-  '@warp-ds/css@1.9.6':
-    resolution: {integrity: sha512-h1weeukiNcbapcCz4JBt71qes8gaPXG/xdWvL3BVcje3MJ3bqIwyYaer4PKfYJRIzeKCg/EWVrzylsKplI5U6Q==}
+  '@warp-ds/css@https://codeload.github.com/warp-ds/css/tar.gz/625349af0401f74238cb7511262e69064c508710':
+    resolution: {tarball: https://codeload.github.com/warp-ds/css/tar.gz/625349af0401f74238cb7511262e69064c508710}
+    version: 1.9.6
 
   '@warp-ds/eslint-config@1.0.5':
     resolution: {integrity: sha512-cHakkN7BVpqwQxpEeDrl3V8/QDco/7UwHTWIFzN3C9t8RlfcT9Y1QTNfMzJQBiIux8oQNE6rom0AydmWLo8mRw==}
@@ -11399,7 +11400,7 @@ snapshots:
     dependencies:
       '@floating-ui/dom': 1.6.5
 
-  '@warp-ds/css@1.9.6':
+  '@warp-ds/css@https://codeload.github.com/warp-ds/css/tar.gz/625349af0401f74238cb7511262e69064c508710':
     dependencies:
       '@warp-ds/tokenizer': 0.0.4
       '@warp-ds/uno': 1.12.0


### PR DESCRIPTION
## Description
This PR ensures no classes styling the same CSS properties are being set on the same HTML element in the Tabs component.
Additionally, this PR fixes [WARP-488](https://nmp-jira.atlassian.net/browse/WARP-488) by restoring a bottom border of subtle gray for the whole Tabs wrapper.

## Testing
Tested the changes by pointing the @warp-ds/css dependency to a feature branch that contains the necessary changes

![gif showing navigation and correct state colors in React Tabs component](https://github.com/warp-ds/css/assets/41303231/f2ce7679-f9ad-4782-add0-4fe900317e1e)