### PR TITLE
feat(toggle): add ReactNode type to toggle labels

### DIFF
--- a/packages/toggle/src/item.tsx
+++ b/packages/toggle/src/item.tsx
@@ -17,7 +17,7 @@ interface ItemProps extends Pick<HTMLInputElement, 'type' | 'name'> {
   invalid?: boolean;
   helpId?: string;
   noVisibleLabel?: boolean;
-  label?: string;
+  label?: string | React.ReactNode;
   className?: string;
   labelClassName?: string;
   inputClassName?: string;

--- a/packages/toggle/src/props.ts
+++ b/packages/toggle/src/props.ts
@@ -1,5 +1,5 @@
 export type ToggleEntry = {
-  label: string;
+  label: string | React.ReactNode;
   value: unknown;
 };
 
@@ -42,7 +42,7 @@ export interface ToggleProps {
   /**
    * If you only need to render a single option, use this prop instead
    */
-  label?: string;
+  label?: string | React.ReactNode;
 
   /**
    * Whether the single option should be checked (controlled)


### PR DESCRIPTION
We will need the React.ReactNode type for labels so that we can add some formatting. Here's an example of desired formatting on the number of hits on search filters:
![Screenshot 2024-06-04 at 10 32 31](https://github.com/warp-ds/react/assets/8958094/6b205356-d9c4-43f2-b3db-608128d52cdd)
