### PR TITLE
chore(deps): allow react 18.3 as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "^18.2.0"
   },
   "scripts": {
     "build-storybook": "storybook build && touch ./storybook-static/.nojekyll",


### PR DESCRIPTION
React 18.3 has been out for a good little while, and it would be nice to avoid warnings if people use that.