### PR TITLE
feat(toggle): export ToggleEntry type

### DIFF
--- a/packages/toggle/src/index.ts
+++ b/packages/toggle/src/index.ts
@@ -1,2 +1,2 @@
 export { Toggle } from './component.js';
-export type { ToggleProps } from './props.js';
+export type { ToggleProps, ToggleEntry } from './props.js';


### PR DESCRIPTION
Exporting the `ToggleEntry` type would make it easier to strongly type the `onChange` handler in the apps using the toggle component.