### PR TITLE
feat: slider onChangeAfter prop

### DIFF
--- a/packages/slider/src/component.tsx
+++ b/packages/slider/src/component.tsx
@@ -7,7 +7,7 @@ import { slider as ccSlider } from '@warp-ds/css/component-classes';
 import { SliderProps } from './props.js';
 
 export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
-  const { disabled, onChange } = rest;
+  const { disabled, onChange, onChangeAfter } = rest;
 
   const sliderLine = useRef<HTMLDivElement | null>(null);
   const thumbRef = useRef<HTMLDivElement | null>(null);
@@ -28,6 +28,11 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
   useEffect(() => {
     onChange && onChange(value);
   }, [value, onChange]);
+
+  useEffect(() => {
+    if (sliderPressed) return;
+    onChangeAfter && onChangeAfter(value);
+  }, [onChangeAfter, sliderPressed, value]);
 
   const step = useMemo(() => rest.step || 1, [rest]);
 

--- a/packages/slider/src/props.ts
+++ b/packages/slider/src/props.ts
@@ -23,7 +23,7 @@ export type SliderProps = {
   /** Handler that is called when the value of the slider changes */
   onChange?: (value: number) => void;
 
-  /** Handler that is called after moving the slider has ended. will only be
+  /** Handler that is called after moving the slider has ended. Will only be
    * called if the action resulted in a change. */
   onChangeAfter?: (value: number) => void;
 

--- a/packages/slider/src/props.ts
+++ b/packages/slider/src/props.ts
@@ -23,6 +23,10 @@ export type SliderProps = {
   /** Handler that is called when the value of the slider changes */
   onChange?: (value: number) => void;
 
+  /** Handler that is called after moving the slider has ended. will only be
+   * called if the action resulted in a change. */
+  onChangeAfter?: (value: number) => void;
+
   /** String value that labels the slider */
   'aria-label'?: string;
 

--- a/packages/slider/stories/Slider.stories.tsx
+++ b/packages/slider/stories/Slider.stories.tsx
@@ -26,3 +26,22 @@ export const Disabled = () => {
     </div>
   );
 };
+
+export const ChangeAfter = () => {
+  const [value, setValue] = React.useState(625_000);
+  const [valueAfter, setValueAfter] = React.useState(value);
+
+  return (
+    <div>
+      <output>{valueAfter}</output>
+      <Slider
+        onChange={(val) => setValue(val)}
+        onChangeAfter={(val) => setValueAfter(val)}
+        value={value}
+        min={1000}
+        max={10_000_000}
+        step={1000}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
This PR adds a new prop to the Slider component that triggers a callback after moving the slider has ended. The motivation behind this change is to perform state updates only after the user is done moving the slider, and not continuously while the slider is being dragged.

A use case for this behaviour is searching with an updated slider value. The search should only be performed for the final slider value, and not for every intermediate value.