### PR TITLE
fix(select): clean up classes

### DIFF
--- a/packages/select/src/component.tsx
+++ b/packages/select/src/component.tsx
@@ -47,23 +47,19 @@ const setup = (props) => {
           : null,
     },
     wrapperClasses: classNames(ccSelect.wrapper, className),
-    selectClasses: classNames({
-      [ccSelect.base]: true,
+
+    selectClasses: classNames(ccSelect.base, {
       [ccSelect.default]: !invalid && !disabled && !readOnly,
       [ccSelect.invalid]: invalid,
       [ccSelect.disabled]: disabled,
       [ccSelect.readOnly]: readOnly,
     }),
-    selectWrapperClasses: classNames({
-      [ccSelect.selectWrapper]: true,
-    }),
-    helpTextClasses: classNames({
-      [ccHelpText.helpText]: true,
+
+    helpTextClasses: classNames(ccHelpText.helpText, {
       [ccHelpText.helpTextColor]: !invalid,
       [ccHelpText.helpTextColorInvalid]: invalid,
     }),
-    chevronClasses: classNames({
-      [ccSelect.chevron]: true,
+    chevronClasses: classNames(ccSelect.chevron, {
       [ccSelect.chevronDisabled]: disabled,
     }),
   };
@@ -71,7 +67,7 @@ const setup = (props) => {
 
 function Select(props: SelectProps, ref: React.Ref<HTMLSelectElement>) {
   const id = useId(props.id);
-  const { attrs, wrapperClasses, selectClasses, selectWrapperClasses, helpTextClasses, chevronClasses } = setup({ ...props, id });
+  const { attrs, wrapperClasses, selectClasses, helpTextClasses, chevronClasses } = setup({ ...props, id });
   const { div, label, select, help, optional } = attrs;
 
   const handleKeyDown = (event) => {
@@ -98,7 +94,7 @@ function Select(props: SelectProps, ref: React.Ref<HTMLSelectElement>) {
           )}
         </label>
       )}
-      <div className={selectWrapperClasses}>
+      <div className={ccSelect.selectWrapper}>
         <select ref={ref} {...select} className={selectClasses} onKeyDown={handleKeyDown} />
         <div className={classNames(chevronClasses)}>
           <IconChevronDown16 />

--- a/packages/select/src/component.tsx
+++ b/packages/select/src/component.tsx
@@ -74,11 +74,11 @@ function Select(props: SelectProps, ref: React.Ref<HTMLSelectElement>) {
   const { attrs, wrapperClasses, selectClasses, selectWrapperClasses, helpTextClasses, chevronClasses } = setup({ ...props, id });
   const { div, label, select, help, optional } = attrs;
 
-    const handleKeyDown = (event) => {
-      if (props.readOnly && (event.key === ' ' || event.key === 'ArrowDown' || event.key === 'ArrowUp')) {
-        event.preventDefault();
-      }
-    };
+  const handleKeyDown = (event) => {
+    if (props.readOnly && (event.key === ' ' || event.key === 'ArrowDown' || event.key === 'ArrowUp')) {
+      event.preventDefault();
+    }
+  };
 
   return (
     <div className={wrapperClasses} {...div}>
@@ -99,7 +99,7 @@ function Select(props: SelectProps, ref: React.Ref<HTMLSelectElement>) {
         </label>
       )}
       <div className={selectWrapperClasses}>
-        <select ref={ref} {...select} className={selectClasses} onKeyDown={handleKeyDown}/>
+        <select ref={ref} {...select} className={selectClasses} onKeyDown={handleKeyDown} />
         <div className={classNames(chevronClasses)}>
           <IconChevronDown16 />
         </div>

--- a/packages/select/src/component.tsx
+++ b/packages/select/src/component.tsx
@@ -74,6 +74,12 @@ function Select(props: SelectProps, ref: React.Ref<HTMLSelectElement>) {
   const { attrs, wrapperClasses, selectClasses, selectWrapperClasses, helpTextClasses, chevronClasses } = setup({ ...props, id });
   const { div, label, select, help, optional } = attrs;
 
+    const handleKeyDown = (event) => {
+      if (props.readOnly && (event.key === ' ' || event.key === 'ArrowDown' || event.key === 'ArrowUp')) {
+        event.preventDefault();
+      }
+    };
+
   return (
     <div className={wrapperClasses} {...div}>
       {label.children && (
@@ -93,7 +99,7 @@ function Select(props: SelectProps, ref: React.Ref<HTMLSelectElement>) {
         </label>
       )}
       <div className={selectWrapperClasses}>
-        <select ref={ref} {...select} className={selectClasses} />
+        <select ref={ref} {...select} className={selectClasses} onKeyDown={handleKeyDown}/>
         <div className={classNames(chevronClasses)}>
           <IconChevronDown16 />
         </div>

--- a/packages/select/src/component.tsx
+++ b/packages/select/src/component.tsx
@@ -48,7 +48,8 @@ const setup = (props) => {
     },
     wrapperClasses: classNames(ccSelect.wrapper, className),
     selectClasses: classNames({
-      [ccSelect.default]: true,
+      [ccSelect.base]: true,
+      [ccSelect.default]: !invalid && !disabled && !readOnly,
       [ccSelect.invalid]: invalid,
       [ccSelect.disabled]: disabled,
       [ccSelect.readOnly]: readOnly,

--- a/packages/select/src/component.tsx
+++ b/packages/select/src/component.tsx
@@ -13,7 +13,7 @@ import { messages as fiMessages } from './locales/fi/messages.mjs';
 import { messages as nbMessages } from './locales/nb/messages.mjs';
 import type { SelectProps } from './props.js';
 
-const setup = (props) => {
+const setup = (props: SelectProps) => {
   const { className, invalid, id, hint, always, label, style, optional, readOnly, disabled, ...rest } = props;
 
   activateI18n(enMessages, nbMessages, fiMessages);

--- a/packages/select/src/props.tsx
+++ b/packages/select/src/props.tsx
@@ -16,6 +16,12 @@ export type SelectProps = {
   /**  Renders the field in an invalid state. Often paired together with `hint` to provide feedback about the error. */
   invalid?: boolean;
 
+  /**  Renders the field in a disabled state.*/
+  disabled?: boolean;
+
+  /**  Renders the field in a read-only state.*/
+  readonly?: boolean;
+
   /** The content to display as the help text. */
   hint?: React.ReactNode;
 

--- a/packages/select/src/props.tsx
+++ b/packages/select/src/props.tsx
@@ -19,7 +19,7 @@ export type SelectProps = {
   /**  Renders the field in a disabled state.*/
   disabled?: boolean;
 
-  /**  Renders the field in a read-only state.*/
+  /**  Renders the field in a readonly state.*/
   readOnly?: boolean;
 
   /** The content to display as the help text. */

--- a/packages/select/src/props.tsx
+++ b/packages/select/src/props.tsx
@@ -20,7 +20,7 @@ export type SelectProps = {
   disabled?: boolean;
 
   /**  Renders the field in a read-only state.*/
-  readonly?: boolean;
+  readOnly?: boolean;
 
   /** The content to display as the help text. */
   hint?: React.ReactNode;

--- a/packages/select/stories/Select.stories.tsx
+++ b/packages/select/stories/Select.stories.tsx
@@ -55,6 +55,12 @@ export const Disabled = () => (
   </div>
 );
 
+export const ReadOnly = () => (
+  <div className="flex flex-col space-y-32">
+    <Select readOnly />
+  </div>
+);
+
 export const NoLabel = () => (
   <div className="flex flex-col space-y-32">
     <WarpSelect onChange={action('change')} onFocus={action('focus')} onBlur={action('blur')} aria-label="You're selection is berry nice!">


### PR DESCRIPTION
## Description
This PR ensures no classes styling the same CSS properties are being set on the same HTML element in the Select component.

Additionally this PR has added missing props `disabled` and `readOnly` to `props.tsx` file for Select and added a missing Select story for `readOnly`. This PR also adds a `handleKeyDown()` function to disable `space`, `arrowUp` and `arrowDown` for when `readOnly` prop is set to `true`

## How to test
Either link this branch with @warp-ds/css (`fix/clean-up-select-classes` branch) or replace this for @warp-ds/css dependency in package.json: `github:warp-ds/css#component-classes-cleanup` with this  `github:warp-ds/css#fix/clean-up-select-classes`