### PR TITLE
fix(slider): prevent onChange/onChangeAfter from being called on initial mount

### DIFF
--- a/packages/slider/src/component.tsx
+++ b/packages/slider/src/component.tsx
@@ -33,15 +33,12 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
 
   const updateValue = useCallback(
     (value: number) => {
-      console.log("updateValue", value);
-
       setValue(value);
       onChange && onChange(value);
 
       if (!sliderPressed) {
         onChangeAfter && onChangeAfter(value);
       }
-  useEffect(() => {
     setHasMounted(true);
     },
     [onChange, onChangeAfter, sliderPressed]
@@ -81,22 +78,28 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
 
   const { handleKeyDown, handleFocus, handleBlur, handleMouseDown, handleClick, getThumbPosition, getThumbTransform, getShiftedChange } =
     createHandlers({ props: { min, max, ...rest }, sliderState });
+    handleFocus,
+    handleBlur,
+    handleMouseDown,
+    handleClick,
+    getThumbPosition,
+  } = createHandlers({ props: { min, max, ...rest }, sliderState });
 
   const thumbPosition = useMemo(getThumbPosition, [getThumbPosition]);
   const sliderActiveStyle = useMemo(
     () => ({
       left: 0,
-      right: 100 - thumbPosition + '%',
+      right: 100 - thumbPosition + "%",
     }),
     [thumbPosition],
+    [thumbPosition]
   );
 
   const transformValue = useMemo(getThumbTransform, [getThumbTransform]);
   const thumbStyles = useMemo(
     () => ({
-      transform: 'translateX(' + transformValue + 'px)',
+      transform: "translateX(" + transformValue + "px)",
     }),
-    [transformValue],
   );
 
   useEffect(() => {
@@ -145,11 +148,11 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
         ref={thumbRef}
         style={thumbStyles}
         aria-label={rest['aria-label']}
-        aria-labelledby={rest['aria-labelledby']}
+        aria-label={rest["aria-label"]}
+        aria-labelledby={rest["aria-labelledby"]}
         aria-valuemin={min}
         aria-valuemax={max}
         aria-valuenow={value}
-        aria-valuetext={rest['aria-valuetext']}
         onMouseDown={(e) => {
           handleMouseDown(e as unknown as KeyboardEvent);
         }}
@@ -160,7 +163,8 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
         onFocus={handleFocus}
         onKeyDown={(e) => {
           handleKeyDown(e as unknown as KeyboardEvent);
-        }}></div>
+        }}
+      ></div>
     </div>
   );
 }

--- a/packages/slider/src/component.tsx
+++ b/packages/slider/src/component.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { classNames } from '@chbphone55/classnames';
 import { createHandlers, useDimensions } from '@warp-ds/core/slider';
@@ -40,7 +34,7 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
         onChangeAfter && onChangeAfter(value);
       }
     },
-    [onChange, onChangeAfter, sliderPressed]
+    [onChange, onChangeAfter, sliderPressed],
   );
 
   const step = useMemo(() => rest.step || 1, [rest]);
@@ -77,12 +71,6 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
 
   const { handleKeyDown, handleFocus, handleBlur, handleMouseDown, handleClick, getThumbPosition, getThumbTransform, getShiftedChange } =
     createHandlers({ props: { min, max, ...rest }, sliderState });
-    handleFocus,
-    handleBlur,
-    handleMouseDown,
-    handleClick,
-    getThumbPosition,
-  } = createHandlers({ props: { min, max, ...rest }, sliderState });
 
   const thumbPosition = useMemo(getThumbPosition, [getThumbPosition]);
   const sliderActiveStyle = useMemo(
@@ -162,8 +150,7 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
         onFocus={handleFocus}
         onKeyDown={(e) => {
           handleKeyDown(e as unknown as KeyboardEvent);
-        }}
-      ></div>
+        }}></div>
     </div>
   );
 }

--- a/packages/slider/src/component.tsx
+++ b/packages/slider/src/component.tsx
@@ -88,7 +88,7 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
   const sliderActiveStyle = useMemo(
     () => ({
       left: 0,
-      right: 100 - thumbPosition + "%",
+      right: 100 - thumbPosition + '%',
     }),
     [thumbPosition],
     [thumbPosition]
@@ -97,8 +97,9 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
   const transformValue = useMemo(getThumbTransform, [getThumbTransform]);
   const thumbStyles = useMemo(
     () => ({
-      transform: "translateX(" + transformValue + "px)",
+      transform: 'translateX(' + transformValue + 'px)',
     }),
+    [transformValue],
   );
 
   useEffect(() => {
@@ -147,8 +148,8 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
         ref={thumbRef}
         style={thumbStyles}
         aria-label={rest['aria-label']}
-        aria-label={rest["aria-label"]}
-        aria-labelledby={rest["aria-labelledby"]}
+        aria-label={rest['aria-label']}
+        aria-labelledby={rest['aria-labelledby']}
         aria-valuemin={min}
         aria-valuemax={max}
         aria-valuenow={value}

--- a/packages/slider/src/component.tsx
+++ b/packages/slider/src/component.tsx
@@ -108,7 +108,7 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
     if (value === n) return;
     updateValue(n);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [position, rest.value, rest.step]);
+  }, [position, rest.value, rest.step, updateValue]);
 
   useEffect(() => {
     if (sliderPressed || position === rest.value || value === rest.value) {

--- a/packages/slider/src/component.tsx
+++ b/packages/slider/src/component.tsx
@@ -24,15 +24,25 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
   const [position, setPosition] = useState(rest.value);
   const [dimensions, setDimensions] = useState({ left: 0, width: 0 });
   const [sliderPressed, setSliderPressed] = useState(false);
+  const [hasMounted, setHasMounted] = useState(false);
 
   useEffect(() => {
-    onChange && onChange(value);
+    if (hasMounted) {
+      onChange && onChange(value);
+    }
   }, [value, onChange]);
 
   useEffect(() => {
-    if (sliderPressed) return;
-    onChangeAfter && onChangeAfter(value);
+    if (hasMounted) {
+      if (!sliderPressed) {
+        onChangeAfter && onChangeAfter(value);
+      }
+    }
   }, [onChangeAfter, sliderPressed, value]);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
 
   const step = useMemo(() => rest.step || 1, [rest]);
 

--- a/packages/slider/src/component.tsx
+++ b/packages/slider/src/component.tsx
@@ -39,7 +39,6 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
       if (!sliderPressed) {
         onChangeAfter && onChangeAfter(value);
       }
-    setHasMounted(true);
     },
     [onChange, onChangeAfter, sliderPressed]
   );

--- a/packages/slider/src/component.tsx
+++ b/packages/slider/src/component.tsx
@@ -91,7 +91,6 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
       right: 100 - thumbPosition + '%',
     }),
     [thumbPosition],
-    [thumbPosition]
   );
 
   const transformValue = useMemo(getThumbTransform, [getThumbTransform]);
@@ -148,11 +147,11 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
         ref={thumbRef}
         style={thumbStyles}
         aria-label={rest['aria-label']}
-        aria-label={rest['aria-label']}
         aria-labelledby={rest['aria-labelledby']}
         aria-valuemin={min}
         aria-valuemax={max}
         aria-valuenow={value}
+        aria-valuetext={rest['aria-valuetext']}
         onMouseDown={(e) => {
           handleMouseDown(e as unknown as KeyboardEvent);
         }}

--- a/packages/slider/src/component.tsx
+++ b/packages/slider/src/component.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { classNames } from '@chbphone55/classnames';
 import { createHandlers, useDimensions } from '@warp-ds/core/slider';
@@ -24,25 +30,22 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
   const [position, setPosition] = useState(rest.value);
   const [dimensions, setDimensions] = useState({ left: 0, width: 0 });
   const [sliderPressed, setSliderPressed] = useState(false);
-  const [hasMounted, setHasMounted] = useState(false);
 
-  useEffect(() => {
-    if (hasMounted) {
+  const updateValue = useCallback(
+    (value: number) => {
+      console.log("updateValue", value);
+
+      setValue(value);
       onChange && onChange(value);
-    }
-  }, [value, onChange]);
 
-  useEffect(() => {
-    if (hasMounted) {
       if (!sliderPressed) {
         onChangeAfter && onChangeAfter(value);
       }
-    }
-  }, [onChangeAfter, sliderPressed, value]);
-
   useEffect(() => {
     setHasMounted(true);
-  }, []);
+    },
+    [onChange, onChangeAfter, sliderPressed]
+  );
 
   const step = useMemo(() => rest.step || 1, [rest]);
 
@@ -63,7 +66,7 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
       return value;
     },
     set val(v) {
-      setValue(v);
+      updateValue(v);
     },
     get thumbEl() {
       return thumbRef.current;
@@ -101,7 +104,7 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
     if (position === rest.value) return;
     const n = rest.step ? getShiftedChange(position) : position;
     if (value === n) return;
-    setValue(n);
+    updateValue(n);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [position, rest.value, rest.step]);
 

--- a/packages/slider/src/component.tsx
+++ b/packages/slider/src/component.tsx
@@ -141,9 +141,15 @@ export function Slider({ min = 0, max = 100, ...rest }: SliderProps) {
         aria-valuenow={value}
         aria-valuetext={rest['aria-valuetext']}
         onMouseDown={(e) => {
+          const clientX = e.clientX || 0;
+          const newPosition = clientX;
+          setPosition(newPosition);
           handleMouseDown(e as unknown as KeyboardEvent);
         }}
         onTouchStart={(e) => {
+          const clientX = e.touches[0]?.clientX || 0;
+          const newPosition = clientX;
+          setPosition(newPosition);
           handleMouseDown(e as unknown as KeyboardEvent);
         }}
         onBlur={handleBlur}

--- a/tests/components/SliderTest.tsx
+++ b/tests/components/SliderTest.tsx
@@ -27,7 +27,6 @@ describe('Slider', () => {
     render(<Slider min={0} max={100} onChange={onChange} />);
     const thumb = screen.getByRole('slider');
     await fireEvent.keyDown(thumb, { key: 'ArrowRight' });
-    // not sure why it gets called twice here
-    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
This PR prevents `onChange` and `onChangeAfter` from being called immediately after the component mounts.

- Added a ref `hasMounted` to track whether the component has mounted.
- Updated the first useEffect to call `onChange(value)` only if the component has already mounted.
- Updated the second useEffect to call `onChangeAfter(value)` only if the component has already mounted and `sliderPressed` is false.
- Introduced a third useEffect to set the `hasMounted` flag to true after the initial render.
- Ensured that both useEffect hooks respect the `hasMounted` flag, preventing them from running their respective logic on the initial mount.
