### PR TITLE
fix: remove deprecated classes

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: lts/*
       - name: Install pnpm and dependencies
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 9
           run_install: true

--- a/.github/workflows/lint.pr.yaml
+++ b/.github/workflows/lint.pr.yaml
@@ -13,7 +13,7 @@ jobs:
       with:
         node-version: lts/*
     - name: Install pnpm and dependencies
-      uses: pnpm/action-setup@v2
+      uses: pnpm/action-setup@v4
       with:
         version: 9
         run_install: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: lts/*
       - name: Install pnpm and dependencies
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 9
           run_install: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: lts/*
       - name: Install pnpm and dependencies
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 9
           run_install: true

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: lts/*
       - name: Install pnpm and dependencies
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 9
           run_install: true

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,6 +1,6 @@
 <link rel="stylesheet" href="https://assets.finn.no/pkg/@warp-ds/fonts/v1/finn-no.css" />
-<link rel="stylesheet" href="https://assets.finn.no/pkg/@warp-ds/css/v1/tokens/finn-no.css" />
-<link rel="stylesheet" href="https://assets.finn.no/pkg/@warp-ds/css/v1/resets.css" />
+<link rel="stylesheet" href="https://assets.finn.no/pkg/@warp-ds/css/v2/tokens/finn-no.css" />
+<link rel="stylesheet" href="https://assets.finn.no/pkg/@warp-ds/css/v2/resets.css" />
 
 <script>
   document.documentElement.setAttribute("lang", 'en');

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@chbphone55/classnames": "2.0.0",
     "@lingui/core": "4.7.0",
     "@warp-ds/core": "1.1.3",
-    "@warp-ds/css": "1.9.6",
+    "@warp-ds/css": "2.0.0-next.2",
     "@warp-ds/icons": "2.0.0",
     "@warp-ds/uno": "1.12.0",
     "react-focus-lock": "2.9.7",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@warp-ds/css": "2.0.0-next.4",
     "react": "^18.0.0"
   },
   "scripts": {
@@ -109,7 +110,6 @@
     "cz-conventional-changelog": "^3.3.0",
     "element-collapse": "^1.0.1",
     "esbuild": "0.19.11",
-    "eslint": "^8.56.0",
     "@warp-ds/eslint-config": "1.0.5",
     "eslint-config-react-app": "^7.0.1",
     "eslint-plugin-flowtype": "^8.0.3",
@@ -139,9 +139,9 @@
     "@chbphone55/classnames": "2.0.0",
     "@lingui/core": "4.7.0",
     "@warp-ds/core": "1.1.3",
-    "@warp-ds/css": "2.0.0-next.2",
+    "@warp-ds/css": "2.0.0-next.4",
     "@warp-ds/icons": "2.0.0",
-    "@warp-ds/uno": "1.12.0",
+    "@warp-ds/uno": "2.x",
     "react-focus-lock": "2.9.7",
     "resize-observer-polyfill": "1.5.1",
     "scroll-doctor": "2.0.2"

--- a/packages/box/src/component.tsx
+++ b/packages/box/src/component.tsx
@@ -6,7 +6,7 @@ import { box as ccBox } from '@warp-ds/css/component-classes';
 import { BoxProps } from './props.js';
 
 export function Box(props: BoxProps) {
-  const { children, as = 'div', bleed, clickable, neutral, bordered, info, role, ...rest } = props;
+  const { children, as = 'div', bleed, neutral, bordered, info, role, ...rest } = props;
 
   return React.createElement(
     as,
@@ -20,9 +20,6 @@ export function Box(props: BoxProps) {
           [ccBox.info]: info,
           [ccBox.neutral]: neutral,
           [ccBox.bordered]: bordered,
-          [ccBox.infoClickable]: clickable && info,
-          [ccBox.neutralClickable]: clickable && neutral,
-          [ccBox.borderedClickable]: clickable && bordered,
         },
         props.className,
       ),

--- a/packages/box/src/props.tsx
+++ b/packages/box/src/props.tsx
@@ -34,12 +34,6 @@ export interface BoxProps {
   bleed?: boolean;
 
   /**
-   * Applies focus and pointer helpers, should be used with other styling to indicate clickability
-   * @default false
-   */
-  clickable?: boolean;
-
-  /**
    * @default false
    */
   bordered?: boolean;

--- a/packages/box/stories/Box.stories.tsx
+++ b/packages/box/stories/Box.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { Clickable } from '../../_helpers';
 import { Box } from '../src';
 
 const metadata = { title: 'Layout/Box' };
@@ -33,28 +32,6 @@ export const Bordered = () => (
 export const Neutral = () => (
   <Box neutral>
     <h1>I am a neutral colour</h1>
-  </Box>
-);
-
-export const ClickableButton = () => (
-  <Box info clickable>
-    <h1>
-      <Clickable className="font-bold" onClick={() => alert('hey')}>
-        Clickable example
-      </Clickable>
-    </h1>
-    <p>Other contents will go here.</p>
-  </Box>
-);
-
-export const ClickableAnchor = () => (
-  <Box info clickable>
-    <h1>
-      <Clickable className="font-bold text-gray-700 hover:no-underline" href="https://finn.no" target="_blank">
-        Clickable example
-      </Clickable>
-    </h1>
-    <p>Other contents will go here.</p>
   </Box>
 );
 

--- a/packages/card/src/component.tsx
+++ b/packages/card/src/component.tsx
@@ -3,17 +3,11 @@ import React from 'react';
 import { classNames } from '@chbphone55/classnames';
 import { card as ccCard } from '@warp-ds/css/component-classes';
 
-import { useLogDeprecationWarning } from '../../utils/src/index.js';
-
 import { CardProps } from './props.js';
 
 export function Card(props: CardProps) {
   const { as = 'div', children, flat, ...rest } = props;
 
-  useLogDeprecationWarning({
-    condition: !!props.onClick,
-    message: "'onClick' prop in Card is deprecated. Use Clickable component to handle click events in Cards.",
-  });
 
   return React.createElement(
     as,
@@ -26,24 +20,8 @@ export function Card(props: CardProps) {
         [ccCard.cardFlat]: props.flat,
         [props.selected ? ccCard.cardFlatSelected : ccCard.cardFlatUnselected]: props.flat,
       }),
-      // @balbinak(08.11.22): onClick support in Card is deprecated. Remove when Fabric React users are ready for this major change
-      tabIndex: props.onClick ? 0 : undefined,
-      onKeyDown: props.onClick
-        ? (e) => {
-            if (typeof props.onClick === 'function' && (e.key === 'Enter' || e.key === ' ')) {
-              e.preventDefault();
-              props.onClick();
-            }
-          }
-        : undefined,
     },
     <>
-      {props.onClick && (
-        <button className="sr-only" aria-pressed={props.selected} tabIndex={-1} type="button">
-          Velg
-        </button>
-      )}
-
       {!props.flat && (
         <div className={classNames([ccCard.cardOutline, props.selected ? ccCard.cardOutlineSelected : ccCard.cardOutlineUnselected])} />
       )}

--- a/packages/card/src/component.tsx
+++ b/packages/card/src/component.tsx
@@ -8,7 +8,6 @@ import { CardProps } from './props.js';
 export function Card(props: CardProps) {
   const { as = 'div', children, flat, ...rest } = props;
 
-
   return React.createElement(
     as,
     {

--- a/packages/card/src/props.tsx
+++ b/packages/card/src/props.tsx
@@ -24,9 +24,4 @@ export interface CardProps {
    * Add your own custom styles to the container element
    */
   className?: string;
-
-  /**
-   * When the card is clicked (deprecated)
-   */
-  onClick?: () => void;
 }

--- a/packages/switch/src/component.tsx
+++ b/packages/switch/src/component.tsx
@@ -9,7 +9,7 @@ export function Switch({ id, value, onClick, 'aria-label': ariaLabel, 'aria-labe
   const switchFocus = 'focusable rounded-full';
 
   return (
-    <div className={ccSwitch.switch}>
+    <div>
       <button
         id={id}
         type="button"

--- a/packages/textarea/src/component.tsx
+++ b/packages/textarea/src/component.tsx
@@ -19,7 +19,6 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, f
   const {
     className,
     disabled,
-    error,
     helpText,
     id: providedId,
     invalid,
@@ -40,7 +39,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, f
   const ref = useRef<HTMLTextAreaElement | null>(null);
 
   const helpId = helpText ? `${id}__hint` : undefined;
-  const isInvalid = invalid ?? error;
+  const isInvalid = invalid;
 
   useTextAreaHeight({
     ref,

--- a/packages/textarea/src/props.ts
+++ b/packages/textarea/src/props.ts
@@ -11,13 +11,6 @@ export type TextAreaProps = {
   /** Whether the input is disabled. */
   disabled?: boolean;
 
-  /**
-   * Renders the field in an invalid state. Often paired together with `helpText` to provide feedback about the error.
-   *
-   * @deprecated use `invalid` instead.
-   */
-  error?: boolean;
-
   /**  Renders the field in an invalid state. Often paired together with `helpText` to provide feedback about the error. */
   invalid?: boolean;
 

--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -19,7 +19,6 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, re
     id: providedId,
     children,
     invalid,
-    error,
     helpText,
     label,
     readOnly,
@@ -33,7 +32,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, re
 
   const id = useId(providedId);
   const helpId = helpText ? `${id}__hint` : undefined;
-  const isInvalid = invalid || error;
+  const isInvalid = invalid;
 
   const suffix = React.Children.toArray(children).find((child) => React.isValidElement(child) && child.props.suffix);
   const prefix = React.Children.toArray(children).find((child) => React.isValidElement(child) && child.props.prefix);

--- a/packages/textfield/src/props.ts
+++ b/packages/textfield/src/props.ts
@@ -11,13 +11,6 @@ export type TextFieldProps = {
   /** Whether the input is disabled. */
   disabled?: boolean;
 
-  /**
-   * Renders the field in an invalid state. Often paired together with `helpText` to provide feedback about the error.
-   *
-   * @deprecated use `invalid` instead.
-   */
-  error?: boolean;
-
   /**  Renders the field in an invalid state. Often paired together with `helpText` to provide feedback about the error. */
   invalid?: boolean;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,14 +18,14 @@ importers:
         specifier: 1.1.3
         version: 1.1.3(@floating-ui/dom@1.6.5)
       '@warp-ds/css':
-        specifier: 2.0.0-next.2
-        version: 2.0.0-next.2
+        specifier: 2.0.0-next.4
+        version: 2.0.0-next.4(@warp-ds/uno@2.0.0(unocss@0.58.9(postcss@8.4.38)(rollup@4.17.2)(vite@5.2.11(@types/node@20.12.12))))
       '@warp-ds/icons':
         specifier: 2.0.0
         version: 2.0.0
       '@warp-ds/uno':
-        specifier: 1.12.0
-        version: 1.12.0
+        specifier: 2.x
+        version: 2.0.0(unocss@0.58.9(postcss@8.4.38)(rollup@4.17.2)(vite@5.2.11(@types/node@20.12.12)))
       react-focus-lock:
         specifier: 2.9.7
         version: 2.9.7(@types/react@18.3.2)(react@18.2.0)
@@ -132,9 +132,6 @@ importers:
       esbuild:
         specifier: 0.19.11
         version: 0.19.11
-      eslint:
-        specifier: ^8.56.0
-        version: 8.57.0
       eslint-config-react-app:
         specifier: ^7.0.1
         version: 7.0.1(@babel/plugin-syntax-flow@7.24.1(@babel/core@7.24.5))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.5))(eslint@8.57.0)(jest@29.7.0(@types/node@20.12.12)(babel-plugin-macros@3.1.0))(typescript@5.3.3)
@@ -3071,8 +3068,10 @@ packages:
     peerDependencies:
       '@floating-ui/dom': 1.6.3
 
-  '@warp-ds/css@2.0.0-next.2':
-    resolution: {integrity: sha512-pB9Xf5qgoMixTGmaOu365gJYlgXM2ICR3PJOah1jvlUH5tEx3vyIo0PMC/p08JrqeH7k+Ki9Sx3EbBpIEYPF7Q==}
+  '@warp-ds/css@2.0.0-next.4':
+    resolution: {integrity: sha512-8DPGjYr+qz7FptHL/e5IPfKWxBTHGBsIi+zZPt8sVIvPAce2aPfIZ5zWjDKEjtVQtKVxrkvgZ4IFsu1K0dZbRQ==}
+    peerDependencies:
+      '@warp-ds/uno': 2.x
 
   '@warp-ds/eslint-config@1.0.5':
     resolution: {integrity: sha512-cHakkN7BVpqwQxpEeDrl3V8/QDco/7UwHTWIFzN3C9t8RlfcT9Y1QTNfMzJQBiIux8oQNE6rom0AydmWLo8mRw==}
@@ -3085,11 +3084,10 @@ packages:
   '@warp-ds/icons@2.0.0':
     resolution: {integrity: sha512-a6Zi9CEunu5V0ScfaG42j5LoPK/U9uL5Gcv+/4D9FNQjaPuissqflUL3YpYI2PxTMIrHuyYXfUMWu8gBVGoUdg==}
 
-  '@warp-ds/tokenizer@0.0.4':
-    resolution: {integrity: sha512-D4qIUQdY0Tp23OpeR6P9T5QXpsr9crN/FusHWN+975Yk5WoWZOMAf7SVyvgFKV0uq5s70I3qlZqjT51khMwPNQ==}
-
-  '@warp-ds/uno@1.12.0':
-    resolution: {integrity: sha512-PVP74/FW95axmFK94IxXqCvGjcRgHJaOgNuTtkK9IZLaHUJGyipf/1Fn4A4mKjaLUo0EhE4V/7rlhB16hakeZw==}
+  '@warp-ds/uno@2.0.0':
+    resolution: {integrity: sha512-1X67+dsZS6m1FMlMkRgEIOww0tRzTrG4wgMGJa6rAZ9Zdb+5BZAkxRqeq+3Bix7iDn3548+NEidLF3uZWNW3aA==}
+    peerDependencies:
+      unocss: 0.x
 
   '@yarnpkg/esbuild-plugin-pnp@3.0.0-rc.15':
     resolution: {integrity: sha512-kYzDJO5CA9sy+on/s2aIW0411AklfCi8Ck/4QDivOqsMKpStZA2SsR+X27VTggGwpStWaLrjJcDcdDMowtG8MA==}
@@ -7770,11 +7768,6 @@ packages:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
 
-  yaml@2.4.2:
-    resolution: {integrity: sha512-B3VqDZ+JAg1nZpaEmWtTXUlBneoGx6CPM9b0TENK6aoSu5t73dItudwdgmi6tHlIZZId4dZ9skcAQ2UbcyAeVA==}
-    engines: {node: '>= 14'}
-    hasBin: true
-
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
@@ -11399,10 +11392,9 @@ snapshots:
     dependencies:
       '@floating-ui/dom': 1.6.5
 
-  '@warp-ds/css@2.0.0-next.2':
+  '@warp-ds/css@2.0.0-next.4(@warp-ds/uno@2.0.0(unocss@0.58.9(postcss@8.4.38)(rollup@4.17.2)(vite@5.2.11(@types/node@20.12.12))))':
     dependencies:
-      '@warp-ds/tokenizer': 0.0.4
-      '@warp-ds/uno': 1.12.0
+      '@warp-ds/uno': 2.0.0(unocss@0.58.9(postcss@8.4.38)(rollup@4.17.2)(vite@5.2.11(@types/node@20.12.12)))
 
   '@warp-ds/eslint-config@1.0.5(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint-plugin-prettier@5.1.3(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.2.5))(eslint@8.57.0)':
     dependencies:
@@ -11415,16 +11407,12 @@ snapshots:
     dependencies:
       '@lingui/core': 4.7.0
 
-  '@warp-ds/tokenizer@0.0.4':
-    dependencies:
-      glob: 10.3.15
-      yaml: 2.4.2
-
-  '@warp-ds/uno@1.12.0':
+  '@warp-ds/uno@2.0.0(unocss@0.58.9(postcss@8.4.38)(rollup@4.17.2)(vite@5.2.11(@types/node@20.12.12)))':
     dependencies:
       '@unocss/core': 0.58.9
       '@unocss/preset-mini': 0.58.9
       '@unocss/rule-utils': 0.58.9
+      unocss: 0.58.9(postcss@8.4.38)(rollup@4.17.2)(vite@5.2.11(@types/node@20.12.12))
 
   '@yarnpkg/esbuild-plugin-pnp@3.0.0-rc.15(esbuild@0.18.20)':
     dependencies:
@@ -16960,8 +16948,6 @@ snapshots:
   yallist@4.0.0: {}
 
   yaml@1.10.2: {}
-
-  yaml@2.4.2: {}
 
   yargs-parser@18.1.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 1.1.3
         version: 1.1.3(@floating-ui/dom@1.6.5)
       '@warp-ds/css':
-        specifier: 1.9.6
-        version: 1.9.6
+        specifier: 2.0.0-next.2
+        version: 2.0.0-next.2
       '@warp-ds/icons':
         specifier: 2.0.0
         version: 2.0.0
@@ -3071,8 +3071,8 @@ packages:
     peerDependencies:
       '@floating-ui/dom': 1.6.3
 
-  '@warp-ds/css@1.9.6':
-    resolution: {integrity: sha512-h1weeukiNcbapcCz4JBt71qes8gaPXG/xdWvL3BVcje3MJ3bqIwyYaer4PKfYJRIzeKCg/EWVrzylsKplI5U6Q==}
+  '@warp-ds/css@2.0.0-next.2':
+    resolution: {integrity: sha512-pB9Xf5qgoMixTGmaOu365gJYlgXM2ICR3PJOah1jvlUH5tEx3vyIo0PMC/p08JrqeH7k+Ki9Sx3EbBpIEYPF7Q==}
 
   '@warp-ds/eslint-config@1.0.5':
     resolution: {integrity: sha512-cHakkN7BVpqwQxpEeDrl3V8/QDco/7UwHTWIFzN3C9t8RlfcT9Y1QTNfMzJQBiIux8oQNE6rom0AydmWLo8mRw==}
@@ -11399,7 +11399,7 @@ snapshots:
     dependencies:
       '@floating-ui/dom': 1.6.5
 
-  '@warp-ds/css@1.9.6':
+  '@warp-ds/css@2.0.0-next.2':
     dependencies:
       '@warp-ds/tokenizer': 0.0.4
       '@warp-ds/uno': 1.12.0

--- a/tests/components/BoxTest.tsx
+++ b/tests/components/BoxTest.tsx
@@ -36,37 +36,4 @@ describe('Box', () => {
     const { container } = render(<Box bordered={true}>Test Box</Box>);
     expect(container.firstChild).toHaveClass('group block relative break-words last-child:mb-0 p-16 rounded-8 border-2 s-border s-bg');
   });
-
-  test('renders Box component with correct classes when clickable and info are true', () => {
-    const { container } = render(
-      <Box clickable={true} info={true}>
-        Test Box
-      </Box>,
-    );
-    expect(container.firstChild).toHaveClass(
-      'group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-info-subtle hover:s-bg-info-subtle-hover active:s-bg-info-subtle-active',
-    );
-  });
-
-  test('renders Box component with correct classes when clickable and neutral are true', () => {
-    const { container } = render(
-      <Box clickable={true} neutral={true}>
-        Test Box
-      </Box>,
-    );
-    expect(container.firstChild).toHaveClass(
-      'group block relative break-words last-child:mb-0 p-16 rounded-8 s-surface-sunken hover:s-bg-hover active:s-bg-active',
-    );
-  });
-
-  test('renders Box component with correct classes when clickable and bordered are true', () => {
-    const { container } = render(
-      <Box clickable={true} bordered={true}>
-        Test Box
-      </Box>,
-    );
-    expect(container.firstChild).toHaveClass(
-      'group block relative break-words last-child:mb-0 p-16 rounded-8 border-2 s-border s-bg hover:s-bg-hover active:s-bg-active hover:s-border-hover active:s-border-active',
-    );
-  });
 });

--- a/tests/components/CardTest.tsx
+++ b/tests/components/CardTest.tsx
@@ -41,29 +41,29 @@ describe('Card', () => {
     );
   });
 
-  it('handles onKeyDown events', () => {
-    const handleClick = vi.fn();
-    render(<Card as="article" onClick={handleClick} />);
-    fireEvent.keyDown(screen.getByRole('article'), { key: 'Enter', code: 'Enter' });
-    expect(handleClick).toHaveBeenCalledTimes(1);
-    fireEvent.keyDown(screen.getByRole('article'), { key: ' ', code: 'Space' });
-    expect(handleClick).toHaveBeenCalledTimes(2);
-  });
+  // it('handles onKeyDown events', () => {
+  //   const handleClick = vi.fn();
+  //   render(<Card as="article" onClick={handleClick} />);
+  //   fireEvent.keyDown(screen.getByRole('article'), { key: 'Enter', code: 'Enter' });
+  //   expect(handleClick).toHaveBeenCalledTimes(1);
+  //   fireEvent.keyDown(screen.getByRole('article'), { key: ' ', code: 'Space' });
+  //   expect(handleClick).toHaveBeenCalledTimes(2);
+  // });
 
-  it('does not call onClick for other keys', () => {
-    const handleClick = vi.fn();
-    render(<Card as="article" onClick={handleClick} />);
-    fireEvent.keyDown(screen.getByRole('article'), { key: 'ArrowRight', code: 'ArrowRight' });
-    expect(handleClick).not.toHaveBeenCalled();
-  });
+  // it('does not call onClick for other keys', () => {
+  //   const handleClick = vi.fn();
+  //   render(<Card as="article" onClick={handleClick} />);
+  //   fireEvent.keyDown(screen.getByRole('article'), { key: 'ArrowRight', code: 'ArrowRight' });
+  //   expect(handleClick).not.toHaveBeenCalled();
+  // });
 
-  it('renders sr-only button when onClick is provided', () => {
-    render(<Card as="article" onClick={() => {}} />);
-    expect(screen.getByRole('button')).toBeInTheDocument();
-  });
+  // it('renders sr-only button when onClick is provided', () => {
+  //   render(<Card as="article" onClick={() => {}} />);
+  //   expect(screen.getByRole('button')).toBeInTheDocument();
+  // });
 
-  it('does not render sr-only button when onClick is not provided', () => {
-    render(<Card />);
-    expect(screen.queryByRole('button')).toBeNull();
-  });
+  // it('does not render sr-only button when onClick is not provided', () => {
+  //   render(<Card />);
+  //   expect(screen.queryByRole('button')).toBeNull();
+  // });
 });

--- a/tests/components/CardTest.tsx
+++ b/tests/components/CardTest.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { Card } from '../../packages/card/src/component';
 
@@ -40,30 +40,4 @@ describe('Card', () => {
       'cursor-pointer overflow-hidden relative transition-all border-2 rounded-4 s-bg-selected hover:s-bg-selected-hover active:s-bg-selected-active s-border-selected hover:s-border-selected-hover active:s-border-selected-active',
     );
   });
-
-  // it('handles onKeyDown events', () => {
-  //   const handleClick = vi.fn();
-  //   render(<Card as="article" onClick={handleClick} />);
-  //   fireEvent.keyDown(screen.getByRole('article'), { key: 'Enter', code: 'Enter' });
-  //   expect(handleClick).toHaveBeenCalledTimes(1);
-  //   fireEvent.keyDown(screen.getByRole('article'), { key: ' ', code: 'Space' });
-  //   expect(handleClick).toHaveBeenCalledTimes(2);
-  // });
-
-  // it('does not call onClick for other keys', () => {
-  //   const handleClick = vi.fn();
-  //   render(<Card as="article" onClick={handleClick} />);
-  //   fireEvent.keyDown(screen.getByRole('article'), { key: 'ArrowRight', code: 'ArrowRight' });
-  //   expect(handleClick).not.toHaveBeenCalled();
-  // });
-
-  // it('renders sr-only button when onClick is provided', () => {
-  //   render(<Card as="article" onClick={() => {}} />);
-  //   expect(screen.getByRole('button')).toBeInTheDocument();
-  // });
-
-  // it('does not render sr-only button when onClick is not provided', () => {
-  //   render(<Card />);
-  //   expect(screen.queryByRole('button')).toBeNull();
-  // });
 });


### PR DESCRIPTION
**Changes:**
- Remove deprecated `clickable` prop from `Box` component, the clickable examples in `Box.stories.tsx` and tests for clickable box in `BoxTest.tsx`.
- Remove deprecated `ccBox.infoClickable`, `ccBox.neutralClickable` and `ccBox.borderedClickable` classes from `Box` component
- Remove deprecated `switch` class from `Switch` component
- Remove deprecated `error` prop from `TextField` and `TextArea` components
- Remove deprecated `onClick` prop from `Card` component and its tests in `CardTest.tsx` file
- Update `@warp-ds/css` dependency to `2.0.0-next.4` and make it also into a peerDependency
- Bump `pnpm/action-setup@v2` to `pnpm/action-setup@v4`
- Bump stylesheet to v2
