### PR TITLE
fix: clean up step and steps classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@warp-ds/css": "2.0.0-next.4",
+    "@warp-ds/css": "github:warp-ds/css#component-classes-cleanup",
     "react": "18.x"
   },
   "scripts": {

--- a/packages/steps/src/component.tsx
+++ b/packages/steps/src/component.tsx
@@ -13,10 +13,10 @@ export const StepsContext = createContext<{
   right: false,
 });
 
-export function Steps({ horizontal, right, className, children }: StepsProps) {
+export function Steps({ horizontal, right, children }: StepsProps) {
   return (
     <StepsContext.Provider value={{ horizontal, right }}>
-      <ul className={classNames(className, { [ccSteps.container]: true, [ccSteps.horizontal]: horizontal })}>{children}</ul>
+      <ul className={classNames(ccSteps.container, { [ccSteps.horizontal]: horizontal })}>{children}</ul>
     </StepsContext.Provider>
   );
 }

--- a/packages/steps/src/component.tsx
+++ b/packages/steps/src/component.tsx
@@ -9,18 +9,14 @@ export const StepsContext = createContext<{
   horizontal?: boolean;
   right?: boolean;
 }>({
-  horizontal: undefined,
-  right: undefined,
+  horizontal: false,
+  right: false,
 });
 
-export function Steps({ horizontal, right, className, children }: StepsProps) {
+export function Steps({ horizontal = false, right = false, className, children }: StepsProps) {
   return (
-    <StepsContext.Provider
-      value={{
-        horizontal: horizontal,
-        right: right,
-      }}>
-      <ul className={classNames(className, [ccSteps.container, { [ccSteps.horizontal]: horizontal }])}>{children}</ul>
+    <StepsContext.Provider value={{ horizontal, right }}>
+      <ul className={classNames(className, { [ccSteps.container]: true, [ccSteps.horizontal]: horizontal })}>{children}</ul>
     </StepsContext.Provider>
   );
 }

--- a/packages/steps/src/component.tsx
+++ b/packages/steps/src/component.tsx
@@ -20,13 +20,7 @@ export function Steps({ horizontal, right, className, children }: StepsProps) {
         horizontal: horizontal,
         right: right,
       }}>
-      <ul
-        className={classNames(className, {
-          [ccSteps.steps]: true,
-          [ccSteps.stepsHorizontal]: horizontal,
-        })}>
-        {children}
-      </ul>
+      <ul className={classNames(className, [ccSteps.container, { [ccSteps.horizontal]: horizontal }])}>{children}</ul>
     </StepsContext.Provider>
   );
 }

--- a/packages/steps/src/component.tsx
+++ b/packages/steps/src/component.tsx
@@ -13,7 +13,7 @@ export const StepsContext = createContext<{
   right: false,
 });
 
-export function Steps({ horizontal = false, right = false, className, children }: StepsProps) {
+export function Steps({ horizontal, right, className, children }: StepsProps) {
   return (
     <StepsContext.Provider value={{ horizontal, right }}>
       <ul className={classNames(className, { [ccSteps.container]: true, [ccSteps.horizontal]: horizontal })}>{children}</ul>

--- a/packages/steps/src/step.tsx
+++ b/packages/steps/src/step.tsx
@@ -76,15 +76,15 @@ export function Step(props: StepProps) {
 
   const lineHorizontalClasses = classNames(
     ccStep.line,
-    ccStep.lineHorizontalAlignLeft,
     ccStep.lineHorizontal,
+    ccStep.lineHorizontalAlignLeft,
     active || completed ? ccStep.lineComplete : ccStep.lineIncomplete,
   );
 
   const dotClasses = classNames(
     ccStep.dot,
-    active || completed ? ccStep.dotActive : ccStep.dotIncomplete,
     vertical ? (!left ? ccStep.dotAlignRight : '') : ccStep.dotHorizontal,
+    active || completed ? ccStep.dotActive : ccStep.dotIncomplete,
   );
 
   const lineClasses = classNames(

--- a/packages/steps/src/step.tsx
+++ b/packages/steps/src/step.tsx
@@ -13,34 +13,8 @@ import { messages as enMessages } from './locales/en/messages.mjs';
 import { messages as fiMessages } from './locales/fi/messages.mjs';
 import { messages as nbMessages } from './locales/nb/messages.mjs';
 
-const availableAriaLabels = {
-  completed: i18n._(
-    /*i18n*/ {
-      id: 'steps.aria.completed',
-      message: 'Step indicator completed circle',
-      comment: 'Completed circle',
-    },
-  ),
-  active: i18n._(
-    /*i18n*/ {
-      id: 'steps.aria.active',
-      message: 'Step indicator active circle',
-      comment: 'Active circle',
-    },
-  ),
-  default: i18n._(
-    /*i18n*/ {
-      id: 'steps.aria.emptyCircle',
-      message: 'Empty circle',
-      comment: 'Empty circle',
-    },
-  ),
-};
+type StepClassKeys = keyof typeof ccStep;
 
-const getAriaLabel = (props: StepProps) => {
-  const ariaLabel = Object.keys(availableAriaLabels).find((a) => props[a]);
-  return ariaLabel ? availableAriaLabels[ariaLabel] : availableAriaLabels.default;
-};
 export interface StepProps {
   /**
    * Step is active
@@ -60,6 +34,51 @@ export interface StepProps {
   children: JSX.Element | JSX.Element[];
 }
 
+const availableAriaLabels = {
+  completed: i18n._({
+    id: 'steps.aria.completed',
+    message: 'Step indicator completed circle',
+    comment: 'Completed circle',
+  }),
+  active: i18n._({
+    id: 'steps.aria.active',
+    message: 'Step indicator active circle',
+    comment: 'Active circle',
+  }),
+  default: i18n._({
+    id: 'steps.aria.emptyCircle',
+    message: 'Empty circle',
+    comment: 'Empty circle',
+  }),
+};
+
+const getAriaLabel = (props: StepProps) => {
+  const ariaLabel = Object.keys(availableAriaLabels).find((a) => props[a as keyof StepProps]);
+  return ariaLabel ? availableAriaLabels[ariaLabel] : availableAriaLabels.default;
+};
+
+/**
+ * getClassNames() returns a combined class string based on a base class and conditional classes.
+ *
+ * @param {StepClassKeys} baseClass - The base class to be included.
+ * @param {Partial<Record<StepClassKeys, boolean>>} conditions - An object with class names as keys and booleans as values indicating whether to include the class.
+ * @returns {string} - A combined class string.
+ */
+const getClassNames = (baseClass: StepClassKeys, conditions: Partial<Record<StepClassKeys, boolean>>): string => {
+  return classNames({
+    [ccStep[baseClass]]: true,
+    ...Object.entries(conditions).reduce(
+      (acc, [key, value]) => {
+        if (value) {
+          acc[ccStep[key as StepClassKeys]] = value;
+        }
+        return acc;
+      },
+      {} as Record<string, boolean>,
+    ),
+  });
+};
+
 export function Step(props: StepProps) {
   activateI18n(enMessages, nbMessages, fiMessages, daMessages);
 
@@ -68,43 +87,39 @@ export function Step(props: StepProps) {
   const vertical = !StepsProps.horizontal;
   const left = !StepsProps.right;
 
-  const stepClasses = classNames({
-    [ccStep.stepVertical]: vertical,
-    [ccStep.stepVerticalLeft]: vertical && left,
-    [ccStep.stepVerticalRight]: vertical && !left,
-    [ccStep.stepHorizontal]: !vertical,
+  const stepClasses = getClassNames('step', {
+    vertical,
+    alignLeft: vertical && left,
+    alignRight: vertical && !left,
+    horizontal: !vertical,
   });
 
-  const stepLineHorizontalClasses = classNames({
-    [ccStep.stepLine]: true,
-    [ccStep.stepLineHorizontalLeft]: true,
-    [ccStep.stepLineHorizontal]: !vertical,
-    [ccStep.stepLineIncomplete]: !active && !completed,
-    [ccStep.stepLineComplete]: active || completed,
+  const stepLineHorizontalClasses = getClassNames('stepLine', {
+    lineHorizontalAlignLeft: true,
+    lineHorizontal: !vertical,
+    lineIncomplete: !active && !completed,
+    lineComplete: active || completed,
   });
 
-  const stepDotClasses = classNames({
-    [ccStep.stepDot]: true,
-    [ccStep.stepDotVerticalRight]: vertical && !left,
-    [ccStep.stepDotHorizontal]: !vertical,
-    [ccStep.stepDotIncomplete]: !(active || completed),
-    [ccStep.stepDotActive]: active || completed,
+  const stepDotClasses = getClassNames('stepDot', {
+    dotAlignRight: vertical && !left,
+    dotHorizontal: !vertical,
+    dotIncomplete: !(active || completed),
+    dotActive: active || completed,
   });
 
-  const stepLineClasses = classNames({
-    [ccStep.stepLine]: true,
-    [ccStep.stepLineHorizontalRight]: true,
-    [ccStep.stepLineVertical]: vertical,
-    [ccStep.stepLineVerticalRight]: vertical && !left,
-    [ccStep.stepLineHorizontal]: !vertical,
-    [ccStep.stepLineIncomplete]: !completed,
-    [ccStep.stepLineComplete]: completed,
+  const stepLineClasses = getClassNames('stepLine', {
+    lineHorizontalAlignRight: true,
+    lineVertical: vertical,
+    lineAlignRight: vertical && !left,
+    lineHorizontal: !vertical,
+    lineIncomplete: !completed,
+    lineComplete: completed,
   });
 
-  const stepContentClasses = classNames({
-    [ccStep.content]: true,
-    [ccStep.contentVertical]: vertical,
-    [ccStep.contentHorizontal]: !vertical,
+  const stepContentClasses = getClassNames('content', {
+    contentVertical: vertical,
+    contentHorizontal: !vertical,
   });
 
   return (

--- a/packages/steps/src/step.tsx
+++ b/packages/steps/src/step.tsx
@@ -68,55 +68,38 @@ export function Step(props: StepProps) {
   const vertical = !StepsProps.horizontal;
   const left = !StepsProps.right;
 
-  const stepClasses = classNames([
-    ccStep.step,
-    {
-      [ccStep.vertical]: vertical,
-      [ccStep.alignLeft]: vertical && left,
-      [ccStep.alignRight]: vertical && !left,
-      [ccStep.horizontal]: !vertical,
-    },
-  ]);
+  const stepClasses = classNames(ccStep.step, {
+    [ccStep.vertical]: vertical,
+    [ccStep.alignLeft]: vertical && left,
+    [ccStep.alignRight]: vertical && !left,
+    [ccStep.horizontal]: !vertical,
+  });
 
-  const lineHorizontalClasses = classNames([
-    ccStep.line,
-    ccStep.lineHorizontalAlignLeft,
-    {
-      [ccStep.lineHorizontal]: !vertical,
-      [ccStep.lineIncomplete]: !active && !completed,
-      [ccStep.lineComplete]: active || completed,
-    },
-  ]);
+  const lineHorizontalClasses = classNames(ccStep.line, ccStep.lineHorizontalAlignLeft, {
+    [ccStep.lineHorizontal]: !vertical,
+    [ccStep.lineIncomplete]: !active && !completed,
+    [ccStep.lineComplete]: active || completed,
+  });
 
-  const dotClasses = classNames([
-    ccStep.dot,
-    {
-      [ccStep.dotAlignRight]: vertical && !left,
-      [ccStep.dotHorizontal]: !vertical,
-      [ccStep.dotIncomplete]: !(active || completed),
-      [ccStep.dotActive]: active || completed,
-    },
-  ]);
+  const dotClasses = classNames(ccStep.dot, {
+    [ccStep.dotAlignRight]: vertical && !left,
+    [ccStep.dotHorizontal]: !vertical,
+    [ccStep.dotIncomplete]: !(active || completed),
+    [ccStep.dotActive]: active || completed,
+  });
 
-  const lineClasses = classNames([
-    ccStep.line,
-    ccStep.lineHorizontalAlignRight,
-    {
-      [ccStep.lineVertical]: vertical,
-      [ccStep.lineAlignRight]: vertical && !left,
-      [ccStep.lineHorizontal]: !vertical,
-      [ccStep.lineIncomplete]: !completed,
-      [ccStep.lineComplete]: completed,
-    },
-  ]);
+  const lineClasses = classNames(ccStep.line, ccStep.lineHorizontalAlignRight, {
+    [ccStep.lineVertical]: vertical,
+    [ccStep.lineAlignRight]: vertical && !left,
+    [ccStep.lineHorizontal]: !vertical,
+    [ccStep.lineIncomplete]: !completed,
+    [ccStep.lineComplete]: completed,
+  });
 
-  const contentClasses = classNames([
-    ccStep.content,
-    {
-      [ccStep.contentVertical]: vertical,
-      [ccStep.contentHorizontal]: !vertical,
-    },
-  ]);
+  const contentClasses = classNames(ccStep.content, {
+    [ccStep.contentVertical]: vertical,
+    [ccStep.contentHorizontal]: !vertical,
+  });
 
   return (
     <li className={stepClasses}>

--- a/packages/steps/src/step.tsx
+++ b/packages/steps/src/step.tsx
@@ -68,38 +68,34 @@ export function Step(props: StepProps) {
   const vertical = !StepsProps.horizontal;
   const left = !StepsProps.right;
 
-  const stepClasses = classNames(ccStep.container, {
-    [ccStep.vertical]: vertical,
-    [ccStep.alignLeft]: vertical && left,
-    [ccStep.alignRight]: vertical && !left,
-    [ccStep.horizontal]: !vertical,
-  });
+  const stepClasses = classNames(
+    ccStep.container,
+    vertical ? ccStep.vertical : ccStep.horizontal,
+    vertical ? (left ? ccStep.alignLeft : ccStep.alignRight) : '',
+  );
 
-  const lineHorizontalClasses = classNames(ccStep.line, ccStep.lineHorizontalAlignLeft, {
-    [ccStep.lineHorizontal]: !vertical,
-    [ccStep.lineIncomplete]: !active && !completed,
-    [ccStep.lineComplete]: active || completed,
-  });
+  const lineHorizontalClasses = classNames(
+    ccStep.line,
+    ccStep.lineHorizontalAlignLeft,
+    ccStep.lineHorizontal,
+    active || completed ? ccStep.lineComplete : ccStep.lineIncomplete,
+  );
 
-  const dotClasses = classNames(ccStep.dot, {
-    [ccStep.dotAlignRight]: vertical && !left,
-    [ccStep.dotHorizontal]: !vertical,
-    [ccStep.dotIncomplete]: !(active || completed),
-    [ccStep.dotActive]: active || completed,
-  });
+  const dotClasses = classNames(
+    ccStep.dot,
+    active || completed ? ccStep.dotActive : ccStep.dotIncomplete,
+    vertical ? (!left ? ccStep.dotAlignRight : '') : ccStep.dotHorizontal,
+  );
 
-  const lineClasses = classNames(ccStep.line, ccStep.lineHorizontalAlignRight, {
-    [ccStep.lineVertical]: vertical,
-    [ccStep.lineAlignRight]: vertical && !left,
-    [ccStep.lineHorizontal]: !vertical,
-    [ccStep.lineIncomplete]: !completed,
-    [ccStep.lineComplete]: completed,
-  });
+  const lineClasses = classNames(
+    ccStep.line,
+    ccStep.lineHorizontalAlignRight,
+    vertical ? ccStep.lineVertical : ccStep.lineHorizontal,
+    vertical && !left ? ccStep.lineAlignRight : '',
+    completed ? ccStep.lineComplete : ccStep.lineIncomplete,
+  );
 
-  const contentClasses = classNames(ccStep.content, {
-    [ccStep.contentVertical]: vertical,
-    [ccStep.contentHorizontal]: !vertical,
-  });
+  const contentClasses = classNames(ccStep.content, vertical ? ccStep.contentVertical : ccStep.contentHorizontal);
 
   return (
     <li className={stepClasses}>

--- a/packages/steps/src/step.tsx
+++ b/packages/steps/src/step.tsx
@@ -68,7 +68,7 @@ export function Step(props: StepProps) {
   const vertical = !StepsProps.horizontal;
   const left = !StepsProps.right;
 
-  const stepClasses = classNames(ccStep.step, {
+  const stepClasses = classNames(ccStep.container, {
     [ccStep.vertical]: vertical,
     [ccStep.alignLeft]: vertical && left,
     [ccStep.alignRight]: vertical && !left,

--- a/packages/steps/src/step.tsx
+++ b/packages/steps/src/step.tsx
@@ -13,8 +13,34 @@ import { messages as enMessages } from './locales/en/messages.mjs';
 import { messages as fiMessages } from './locales/fi/messages.mjs';
 import { messages as nbMessages } from './locales/nb/messages.mjs';
 
-type StepClassKeys = keyof typeof ccStep;
+const availableAriaLabels = {
+  completed: i18n._(
+    /*i18n*/ {
+      id: 'steps.aria.completed',
+      message: 'Step indicator completed circle',
+      comment: 'Completed circle',
+    },
+  ),
+  active: i18n._(
+    /*i18n*/ {
+      id: 'steps.aria.active',
+      message: 'Step indicator active circle',
+      comment: 'Active circle',
+    },
+  ),
+  default: i18n._(
+    /*i18n*/ {
+      id: 'steps.aria.emptyCircle',
+      message: 'Empty circle',
+      comment: 'Empty circle',
+    },
+  ),
+};
 
+const getAriaLabel = (props: StepProps) => {
+  const ariaLabel = Object.keys(availableAriaLabels).find((a) => props[a]);
+  return ariaLabel ? availableAriaLabels[ariaLabel] : availableAriaLabels.default;
+};
 export interface StepProps {
   /**
    * Step is active
@@ -34,51 +60,6 @@ export interface StepProps {
   children: JSX.Element | JSX.Element[];
 }
 
-const availableAriaLabels = {
-  completed: i18n._({
-    id: 'steps.aria.completed',
-    message: 'Step indicator completed circle',
-    comment: 'Completed circle',
-  }),
-  active: i18n._({
-    id: 'steps.aria.active',
-    message: 'Step indicator active circle',
-    comment: 'Active circle',
-  }),
-  default: i18n._({
-    id: 'steps.aria.emptyCircle',
-    message: 'Empty circle',
-    comment: 'Empty circle',
-  }),
-};
-
-const getAriaLabel = (props: StepProps) => {
-  const ariaLabel = Object.keys(availableAriaLabels).find((a) => props[a as keyof StepProps]);
-  return ariaLabel ? availableAriaLabels[ariaLabel] : availableAriaLabels.default;
-};
-
-/**
- * getClassNames() returns a combined class string based on a base class and conditional classes.
- *
- * @param {StepClassKeys} baseClass - The base class to be included.
- * @param {Partial<Record<StepClassKeys, boolean>>} conditions - An object with class names as keys and booleans as values indicating whether to include the class.
- * @returns {string} - A combined class string.
- */
-const getClassNames = (baseClass: StepClassKeys, conditions: Partial<Record<StepClassKeys, boolean>>): string => {
-  return classNames({
-    [ccStep[baseClass]]: true,
-    ...Object.entries(conditions).reduce(
-      (acc, [key, value]) => {
-        if (value) {
-          acc[ccStep[key as StepClassKeys]] = value;
-        }
-        return acc;
-      },
-      {} as Record<string, boolean>,
-    ),
-  });
-};
-
 export function Step(props: StepProps) {
   activateI18n(enMessages, nbMessages, fiMessages, daMessages);
 
@@ -87,49 +68,64 @@ export function Step(props: StepProps) {
   const vertical = !StepsProps.horizontal;
   const left = !StepsProps.right;
 
-  const stepClasses = getClassNames('step', {
-    vertical,
-    alignLeft: vertical && left,
-    alignRight: vertical && !left,
-    horizontal: !vertical,
-  });
+  const stepClasses = classNames([
+    ccStep.step,
+    {
+      [ccStep.vertical]: vertical,
+      [ccStep.alignLeft]: vertical && left,
+      [ccStep.alignRight]: vertical && !left,
+      [ccStep.horizontal]: !vertical,
+    },
+  ]);
 
-  const stepLineHorizontalClasses = getClassNames('stepLine', {
-    lineHorizontalAlignLeft: true,
-    lineHorizontal: !vertical,
-    lineIncomplete: !active && !completed,
-    lineComplete: active || completed,
-  });
+  const lineHorizontalClasses = classNames([
+    ccStep.line,
+    ccStep.lineHorizontalAlignLeft,
+    {
+      [ccStep.lineHorizontal]: !vertical,
+      [ccStep.lineIncomplete]: !active && !completed,
+      [ccStep.lineComplete]: active || completed,
+    },
+  ]);
 
-  const stepDotClasses = getClassNames('stepDot', {
-    dotAlignRight: vertical && !left,
-    dotHorizontal: !vertical,
-    dotIncomplete: !(active || completed),
-    dotActive: active || completed,
-  });
+  const dotClasses = classNames([
+    ccStep.dot,
+    {
+      [ccStep.dotAlignRight]: vertical && !left,
+      [ccStep.dotHorizontal]: !vertical,
+      [ccStep.dotIncomplete]: !(active || completed),
+      [ccStep.dotActive]: active || completed,
+    },
+  ]);
 
-  const stepLineClasses = getClassNames('stepLine', {
-    lineHorizontalAlignRight: true,
-    lineVertical: vertical,
-    lineAlignRight: vertical && !left,
-    lineHorizontal: !vertical,
-    lineIncomplete: !completed,
-    lineComplete: completed,
-  });
+  const lineClasses = classNames([
+    ccStep.line,
+    ccStep.lineHorizontalAlignRight,
+    {
+      [ccStep.lineVertical]: vertical,
+      [ccStep.lineAlignRight]: vertical && !left,
+      [ccStep.lineHorizontal]: !vertical,
+      [ccStep.lineIncomplete]: !completed,
+      [ccStep.lineComplete]: completed,
+    },
+  ]);
 
-  const stepContentClasses = getClassNames('content', {
-    contentVertical: vertical,
-    contentHorizontal: !vertical,
-  });
+  const contentClasses = classNames([
+    ccStep.content,
+    {
+      [ccStep.contentVertical]: vertical,
+      [ccStep.contentHorizontal]: !vertical,
+    },
+  ]);
 
   return (
     <li className={stepClasses}>
-      {!vertical && <div className={stepLineHorizontalClasses} />}
-      <div className={stepDotClasses} role="img" aria-label={getAriaLabel(props)} {...(active && { 'aria-current': 'step' })}>
+      {!vertical && <div className={lineHorizontalClasses} />}
+      <div className={dotClasses} role="img" aria-label={getAriaLabel(props)} {...(active && { 'aria-current': 'step' })}>
         {completed && <IconCheck16 data-testid="completed-icon" />}
       </div>
-      <div className={stepLineClasses} />
-      <div className={stepContentClasses}>{children}</div>
+      <div className={lineClasses} />
+      <div className={contentClasses}>{children}</div>
     </li>
   );
 }

--- a/tests/components/StepsTest.tsx
+++ b/tests/components/StepsTest.tsx
@@ -6,13 +6,13 @@ import { Steps } from '../../packages/steps/src/component';
 import { Step } from '../../packages/steps/src/step';
 
 describe('Steps component', () => {
-  it('renders a ul element with the correct class names', () => {
+  it('renders a ul element with the correct class names for horizontal steps', () => {
     const { container } = render(<Steps horizontal={true} right={false} />);
     const ulElement = container.querySelector('ul');
     expect(ulElement).toHaveClass('w-full flex');
   });
 
-  it('renders a ul element with the correct class names vertical', () => {
+  it('renders a ul element with the correct class names for vertical steps', () => {
     const { container } = render(<Steps horizontal={false} right={false} />);
     const ulElement = container.querySelector('ul');
     expect(ulElement).toHaveClass('w-full');
@@ -28,7 +28,7 @@ describe('Steps component', () => {
 describe('Step component', () => {
   it('renders correctly with default props', () => {
     const { container } = render(<Step>Step content</Step>);
-    // dom is a bit complicated hence snapshot testing
+    // DOM is a bit complicated hence snapshot testing
     expect(container).toMatchSnapshot();
   });
 

--- a/tests/components/__snapshots__/StepsTest.tsx.snap
+++ b/tests/components/__snapshots__/StepsTest.tsx.snap
@@ -3,19 +3,19 @@
 exports[`Step component > renders correctly with active prop 1`] = `
 <div>
   <li
-    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]"
+    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]  "
   >
     <div
       aria-current="step"
       aria-label="Step indicator active circle"
-      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted s-border-primary s-bg-primary"
+      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted    s-border-primary s-bg-primary"
       role="img"
     />
     <div
-      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center s-bg-disabled"
+      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center   s-bg-disabled "
     />
     <div
-      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32"
+      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32 "
     >
       Step content
     </div>
@@ -26,12 +26,12 @@ exports[`Step component > renders correctly with active prop 1`] = `
 exports[`Step component > renders correctly with both active and completed props 1`] = `
 <div>
   <li
-    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]"
+    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]  "
   >
     <div
       aria-current="step"
       aria-label="Step indicator completed circle"
-      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted s-border-primary s-bg-primary"
+      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted    s-border-primary s-bg-primary"
       role="img"
     >
       <svg
@@ -55,10 +55,10 @@ exports[`Step component > renders correctly with both active and completed props
       </svg>
     </div>
     <div
-      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center s-bg-primary"
+      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center    s-bg-primary"
     />
     <div
-      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32"
+      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32 "
     >
       Step content
     </div>
@@ -69,11 +69,11 @@ exports[`Step component > renders correctly with both active and completed props
 exports[`Step component > renders correctly with completed prop 1`] = `
 <div>
   <li
-    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]"
+    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]  "
   >
     <div
       aria-label="Step indicator completed circle"
-      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted s-border-primary s-bg-primary"
+      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted    s-border-primary s-bg-primary"
       role="img"
     >
       <svg
@@ -97,10 +97,10 @@ exports[`Step component > renders correctly with completed prop 1`] = `
       </svg>
     </div>
     <div
-      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center s-bg-primary"
+      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center    s-bg-primary"
     />
     <div
-      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32"
+      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32 "
     >
       Step content
     </div>
@@ -111,18 +111,18 @@ exports[`Step component > renders correctly with completed prop 1`] = `
 exports[`Step component > renders correctly with default props 1`] = `
 <div>
   <li
-    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]"
+    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]  "
   >
     <div
       aria-label="Empty circle"
-      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted s-border s-bg"
+      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted   s-border s-bg "
       role="img"
     />
     <div
-      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center s-bg-disabled"
+      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center   s-bg-disabled "
     />
     <div
-      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32"
+      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32 "
     >
       Step content
     </div>

--- a/tests/components/__snapshots__/StepsTest.tsx.snap
+++ b/tests/components/__snapshots__/StepsTest.tsx.snap
@@ -3,19 +3,19 @@
 exports[`Step component > renders correctly with active prop 1`] = `
 <div>
   <li
-    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]  "
+    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]"
   >
     <div
       aria-current="step"
       aria-label="Step indicator active circle"
-      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted    s-border-primary s-bg-primary"
+      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted s-border-primary s-bg-primary "
       role="img"
     />
     <div
-      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center   s-bg-disabled "
+      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center  s-bg-disabled"
     />
     <div
-      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32 "
+      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32"
     >
       Step content
     </div>
@@ -26,12 +26,12 @@ exports[`Step component > renders correctly with active prop 1`] = `
 exports[`Step component > renders correctly with both active and completed props 1`] = `
 <div>
   <li
-    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]  "
+    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]"
   >
     <div
       aria-current="step"
       aria-label="Step indicator completed circle"
-      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted    s-border-primary s-bg-primary"
+      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted s-border-primary s-bg-primary "
       role="img"
     >
       <svg
@@ -55,10 +55,10 @@ exports[`Step component > renders correctly with both active and completed props
       </svg>
     </div>
     <div
-      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center    s-bg-primary"
+      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center  s-bg-primary"
     />
     <div
-      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32 "
+      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32"
     >
       Step content
     </div>
@@ -69,11 +69,11 @@ exports[`Step component > renders correctly with both active and completed props
 exports[`Step component > renders correctly with completed prop 1`] = `
 <div>
   <li
-    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]  "
+    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]"
   >
     <div
       aria-label="Step indicator completed circle"
-      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted    s-border-primary s-bg-primary"
+      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted s-border-primary s-bg-primary "
       role="img"
     >
       <svg
@@ -97,10 +97,10 @@ exports[`Step component > renders correctly with completed prop 1`] = `
       </svg>
     </div>
     <div
-      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center    s-bg-primary"
+      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center  s-bg-primary"
     />
     <div
-      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32 "
+      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32"
     >
       Step content
     </div>
@@ -111,18 +111,18 @@ exports[`Step component > renders correctly with completed prop 1`] = `
 exports[`Step component > renders correctly with default props 1`] = `
 <div>
   <li
-    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]  "
+    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]"
   >
     <div
       aria-label="Empty circle"
-      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted   s-border s-bg "
+      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted s-border s-bg "
       role="img"
     />
     <div
-      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center   s-bg-disabled "
+      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center  s-bg-disabled"
     />
     <div
-      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32 "
+      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32"
     >
       Step content
     </div>

--- a/tests/components/__snapshots__/StepsTest.tsx.snap
+++ b/tests/components/__snapshots__/StepsTest.tsx.snap
@@ -3,19 +3,19 @@
 exports[`Step component > renders correctly with active prop 1`] = `
 <div>
   <li
-    class="group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]  "
+    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]"
   >
     <div
       aria-current="step"
       aria-label="Step indicator active circle"
-      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted    s-border-primary s-bg-primary"
+      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted s-border-primary s-bg-primary"
       role="img"
     />
     <div
-      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center   s-bg-disabled "
+      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center s-bg-disabled"
     />
     <div
-      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32 "
+      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32"
     >
       Step content
     </div>
@@ -26,12 +26,12 @@ exports[`Step component > renders correctly with active prop 1`] = `
 exports[`Step component > renders correctly with both active and completed props 1`] = `
 <div>
   <li
-    class="group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]  "
+    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]"
   >
     <div
       aria-current="step"
       aria-label="Step indicator completed circle"
-      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted    s-border-primary s-bg-primary"
+      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted s-border-primary s-bg-primary"
       role="img"
     >
       <svg
@@ -55,10 +55,10 @@ exports[`Step component > renders correctly with both active and completed props
       </svg>
     </div>
     <div
-      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center    s-bg-primary"
+      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center s-bg-primary"
     />
     <div
-      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32 "
+      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32"
     >
       Step content
     </div>
@@ -69,11 +69,11 @@ exports[`Step component > renders correctly with both active and completed props
 exports[`Step component > renders correctly with completed prop 1`] = `
 <div>
   <li
-    class="group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]  "
+    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]"
   >
     <div
       aria-label="Step indicator completed circle"
-      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted    s-border-primary s-bg-primary"
+      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted s-border-primary s-bg-primary"
       role="img"
     >
       <svg
@@ -97,10 +97,10 @@ exports[`Step component > renders correctly with completed prop 1`] = `
       </svg>
     </div>
     <div
-      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center    s-bg-primary"
+      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center s-bg-primary"
     />
     <div
-      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32 "
+      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32"
     >
       Step content
     </div>
@@ -111,18 +111,18 @@ exports[`Step component > renders correctly with completed prop 1`] = `
 exports[`Step component > renders correctly with default props 1`] = `
 <div>
   <li
-    class="group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]  "
+    class="group/step group/stepv grid-rows-[20px_auto] grid grid-flow-col gap-x-16 grid-cols-[20px_1fr]"
   >
     <div
       aria-label="Empty circle"
-      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted   s-border s-bg "
+      class="rounded-full border-2 h-20 w-20 transition-colors duration-300 s-icon-inverted s-border s-bg"
       role="img"
     />
     <div
-      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center   s-bg-disabled "
+      class="group-last/stepv:hidden transition-colors duration-300 group-last/steph:bg-transparent w-2 h-full justify-self-center s-bg-disabled"
     />
     <div
-      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32 "
+      class="last:mb-0 group-last/step:last:pb-0 row-span-2 pb-32"
     >
       Step content
     </div>


### PR DESCRIPTION
## Description
This PR ensures no classes styling the same CSS properties are being set on the same HTML element in the `Step` and `Steps` components.

**Changes:**
- Renamed classNames in `Step` and `Steps` components.

## How to test
Either link this branch with @warp-ds/css (`fix/cleanup-steps-classes` branch) or replace this for @warp-ds/css dependency in package.json: `github:warp-ds/css#component-classes-cleanup` with this  `github:warp-ds/css#fix/cleanup-steps-classes`