### PR TITLE
fix(expandable): clean up classes

### DIFF
--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -14,7 +14,6 @@ export function Expandable(props: ExpandableProps) {
     children,
     expanded = false,
     title = '',
-    info = false,
     box = false,
     bleed = false,
     buttonClass = '',
@@ -39,12 +38,7 @@ export function Expandable(props: ExpandableProps) {
     if (onChange) onChange(!stateExpanded);
   };
 
-  const wrapperClasses = classNames([
-    ccExpandable.expandable,
-    box && ccExpandable.expandableBox,
-    info && box && ccExpandable.expandableInfo,
-    bleed && ccExpandable.expandableBleed,
-  ]);
+  const wrapperClasses = classNames([ccExpandable.expandable, box && ccExpandable.expandableBox, bleed && ccExpandable.expandableBleed]);
 
   const buttonClasses = classNames(buttonClass, [ccExpandable.button, box && ccExpandable.buttonBox]);
 
@@ -58,7 +52,7 @@ export function Expandable(props: ExpandableProps) {
     return stateExpanded ? <IconChevronUp16 className={upClasses} /> : <IconChevronDown16 className={downClasses} />;
   };
 
-  const contentClasses = classNames(contentClass, [box && ccBox.box, (box || info) && title && ccExpandable.paddingTop]);
+  const contentClasses = classNames(contentClass, [box && ccBox.box, box && title && ccExpandable.paddingTop]);
 
   return (
     <div {...rest} className={wrapperClasses}>

--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -27,15 +27,19 @@ export function Expandable(props: ExpandableProps) {
   } = props;
 
   const [stateExpanded, setStateExpanded] = React.useState(expanded);
+  const [showChevronUp, setShowChevronUp] = React.useState(expanded);
 
   React.useEffect(() => {
     setStateExpanded(expanded);
   }, [expanded]);
 
-  const toggleExpandable = () => {
-    setStateExpanded(!stateExpanded);
-
-    if (onChange) onChange(!stateExpanded);
+  const toggleExpandable = (state) => {
+    setStateExpanded(!state);
+    // We need a slight delay for the animation since it has a transition-duration of 150ms:
+    setTimeout(() => {
+      setShowChevronUp(!state);
+    }, 200);
+    if (onChange) onChange(!state);
   };
 
   const wrapperClasses = classNames([ccExpandable.expandable, box && ccExpandable.expandableBox, bleed && ccExpandable.expandableBleed]);
@@ -45,11 +49,10 @@ export function Expandable(props: ExpandableProps) {
   const chevronClasses = classNames([ccExpandable.chevron, !box && ccExpandable.chevronNonBox]);
 
   const chevronIcon = () => {
-    const upClasses = classNames([ccExpandable.chevronTransform, !stateExpanded && ccExpandable.chevronCollapse]);
+    const upClasses = classNames([ccExpandable.chevronTransform, !stateExpanded && showChevronUp && ccExpandable.chevronCollapse]);
+    const downClasses = classNames([ccExpandable.chevronTransform, stateExpanded && !showChevronUp && ccExpandable.chevronExpand]);
 
-    const downClasses = classNames([ccExpandable.chevronTransform, stateExpanded && ccExpandable.chevronExpand]);
-
-    return stateExpanded ? <IconChevronUp16 className={upClasses} /> : <IconChevronDown16 className={downClasses} />;
+    return showChevronUp ? <IconChevronUp16 className={upClasses} /> : <IconChevronDown16 className={downClasses} />;
   };
 
   const contentClasses = classNames(contentClass, [box && ccBox.box, box && title && ccExpandable.contentWithTitle]);
@@ -57,7 +60,7 @@ export function Expandable(props: ExpandableProps) {
   return (
     <div {...rest} className={wrapperClasses}>
       <UnstyledHeading level={headingLevel}>
-        <button type="button" aria-expanded={stateExpanded} className={buttonClasses} onClick={toggleExpandable}>
+        <button type="button" aria-expanded={stateExpanded} className={buttonClasses} onClick={() => toggleExpandable(stateExpanded)}>
           <div className={ccExpandable.title}>
             {typeof title === 'string' ? <span className={ccExpandable.titleType}>{title}</span> : title}
             {chevron && <div className={chevronClasses}>{chevronIcon()}</div>}

--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -34,17 +34,18 @@ export function Expandable(props: ExpandableProps) {
   }, [expanded]);
 
   const toggleExpandable = () => {
-    const newState = !stateExpanded;
-    setStateExpanded(newState);
+    setStateExpanded(!stateExpanded);
 
-    if (onChange) onChange(newState);
+    if (onChange) onChange(!stateExpanded);
   };
 
-  const chevronIcon = stateExpanded ? (
-    <IconChevronUp16 className={classNames([ccExpandable.chevronTransform, !stateExpanded && ccExpandable.chevronCollapse])} />
-  ) : (
-    <IconChevronDown16 className={classNames([ccExpandable.chevronTransform, stateExpanded && ccExpandable.chevronExpand])} />
-  );
+  const chevronIcon = () => {
+    const upClasses = classNames([ccExpandable.chevronTransform, !stateExpanded && ccExpandable.chevronCollapse]);
+
+    const downClasses = classNames([ccExpandable.chevronTransform, stateExpanded && ccExpandable.chevronExpand]);
+
+    return stateExpanded ? <IconChevronUp16 className={upClasses} /> : <IconChevronDown16 className={downClasses} />;
+  };
 
   return (
     <div
@@ -63,7 +64,7 @@ export function Expandable(props: ExpandableProps) {
           onClick={toggleExpandable}>
           <div className={ccExpandable.title}>
             {typeof title === 'string' ? <span className={ccExpandable.titleType}>{title}</span> : title}
-            {chevron && <div className={classNames([ccExpandable.chevron, !box && ccExpandable.chevronNonBox])}>{chevronIcon}</div>}
+            {chevron && <div className={classNames([ccExpandable.chevron, !box && ccExpandable.chevronNonBox])}>{chevronIcon()}</div>}
           </div>
         </button>
       </UnstyledHeading>

--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -52,7 +52,7 @@ export function Expandable(props: ExpandableProps) {
     return stateExpanded ? <IconChevronUp16 className={upClasses} /> : <IconChevronDown16 className={downClasses} />;
   };
 
-  const contentClasses = classNames(contentClass, [box && ccBox.box, box && title && ccExpandable.paddingTop]);
+  const contentClasses = classNames(contentClass, [box && ccBox.box, box && title && ccExpandable.contentWithTitle]);
 
   return (
     <div {...rest} className={wrapperClasses}>

--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -39,6 +39,17 @@ export function Expandable(props: ExpandableProps) {
     if (onChange) onChange(!stateExpanded);
   };
 
+  const wrapperClasses = classNames([
+    ccExpandable.expandable,
+    box && ccExpandable.expandableBox,
+    info && box && ccExpandable.expandableInfo,
+    bleed && ccExpandable.expandableBleed,
+  ]);
+
+  const buttonClasses = classNames(buttonClass, [ccExpandable.button, box && ccExpandable.buttonBox]);
+
+  const chevronClasses = classNames([ccExpandable.chevron, !box && ccExpandable.chevronNonBox]);
+
   const chevronIcon = () => {
     const upClasses = classNames([ccExpandable.chevronTransform, !stateExpanded && ccExpandable.chevronCollapse]);
 
@@ -47,48 +58,32 @@ export function Expandable(props: ExpandableProps) {
     return stateExpanded ? <IconChevronUp16 className={upClasses} /> : <IconChevronDown16 className={downClasses} />;
   };
 
+  const contentClasses = classNames(contentClass, [box && ccBox.box, box && title && ccExpandable.paddingTop]);
+
   return (
-    <div
-      {...rest}
-      className={classNames(className, [
-        ccExpandable.expandable,
-        box && ccExpandable.expandableBox,
-        info && box && ccExpandable.expandableInfo,
-        bleed && ccExpandable.expandableBleed,
-      ])}>
+    <div {...rest} className={wrapperClasses}>
       <UnstyledHeading level={headingLevel}>
-        <button
-          type="button"
-          aria-expanded={stateExpanded}
-          className={classNames(buttonClass, [ccExpandable.button, box && ccExpandable.buttonBox])}
-          onClick={toggleExpandable}>
+        <button type="button" aria-expanded={stateExpanded} className={buttonClasses} onClick={toggleExpandable}>
           <div className={ccExpandable.title}>
             {typeof title === 'string' ? <span className={ccExpandable.titleType}>{title}</span> : title}
-            {chevron && <div className={classNames([ccExpandable.chevron, !box && ccExpandable.chevronNonBox])}>{chevronIcon()}</div>}
+            {chevron && <div className={chevronClasses}>{chevronIcon()}</div>}
           </div>
         </button>
       </UnstyledHeading>
       <ExpansionBehaviour animated={animated} stateExpanded={stateExpanded}>
-        <div
-          className={classNames(contentClass, {
-            [ccBox.box]: box,
-            [ccExpandable.paddingTop]: box && title,
-          })}>
-          {children}
-        </div>
+        <div className={contentClasses}>{children}</div>
       </ExpansionBehaviour>
     </div>
   );
 }
 
 function ExpansionBehaviour({ animated, stateExpanded, children }) {
+  const expansionClasses = classNames([ccExpandable.expansion, !stateExpanded && ccExpandable.expansionNotExpanded]);
+
   return animated ? (
     <ExpandTransition show={stateExpanded}>{children}</ExpandTransition>
   ) : (
-    <div
-      className={classNames([ccExpandable.expansion, !stateExpanded && ccExpandable.expansionNotExpanded])}
-      data-testid="expandable-content"
-      aria-hidden={!stateExpanded ? true : undefined}>
+    <div className={expansionClasses} data-testid="expandable-content" aria-hidden={!stateExpanded ? true : undefined}>
       {children}
     </div>
   );

--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -10,76 +10,78 @@ import { ExpandTransition, UnstyledHeading } from '../../_helpers/index.js';
 import type { ExpandableProps } from './props.js';
 
 export function Expandable(props: ExpandableProps) {
-  // eslint-disable-next-line
-  const { children, expanded = false, title = '', info = false, box = false, bleed = false, buttonClass = '', contentClass = '', className, onChange, chevron = true, animated, headingLevel, ...rest } = props;
+  const {
+    children,
+    expanded = false,
+    title = '',
+    info = false,
+    box = false,
+    bleed = false,
+    buttonClass = '',
+    contentClass = '',
+    className,
+    onChange,
+    chevron = true,
+    animated,
+    headingLevel,
+    ...rest
+  } = props;
 
   const [stateExpanded, setStateExpanded] = React.useState(expanded);
-  const [showChevronUp, setShowChevronUp] = React.useState(expanded);
 
   React.useEffect(() => {
     setStateExpanded(expanded);
   }, [expanded]);
 
-  const toggleExpandable = (state) => {
-    setStateExpanded(!state);
-    // We need a slight delay for the animation since it has a transition-duration of 150ms:
-    setTimeout(() => {
-      setShowChevronUp(!state);
-    }, 200);
-    if (onChange) onChange(!state);
+  const toggleExpandable = () => {
+    const newState = !stateExpanded;
+    setStateExpanded(newState);
+
+    if (onChange) onChange(newState);
   };
+
+  const chevronIcon = stateExpanded ? (
+    <IconChevronUp16
+      className={classNames([
+        ccExpandable.chevronTransform,
+        ccExpandable.elementsTransformChevronUpPart,
+        !stateExpanded && [ccExpandable.chevronCollapse, ccExpandable.elementsChevronUpCollapsePart],
+      ])}
+    />
+  ) : (
+    <IconChevronDown16
+      className={classNames([
+        ccExpandable.chevronTransform,
+        ccExpandable.elementsTransformChevronDownPart,
+        stateExpanded && [ccExpandable.chevronExpand, ccExpandable.elementsChevronDownExpandPart],
+      ])}
+    />
+  );
 
   return (
     <div
       {...rest}
-      className={classNames(className, {
-        [ccExpandable.expandable]: true,
-        [ccExpandable.expandableBox]: box,
-        [ccExpandable.expandableBleed]: bleed,
-      })}>
+      className={classNames(className, [
+        ccExpandable.expandable,
+        box && ccExpandable.expandableBox,
+        info && box && ccExpandable.expandableInfo,
+        bleed && ccExpandable.expandableBleed,
+      ])}>
       <UnstyledHeading level={headingLevel}>
         <button
           type="button"
           aria-expanded={stateExpanded}
-          className={classNames({
-            [buttonClass || '']: true,
-            [ccExpandable.button]: true,
-            [ccExpandable.buttonBox]: box,
-          })}
-          onClick={() => toggleExpandable(stateExpanded)}>
+          className={classNames(buttonClass, [ccExpandable.button, box && ccExpandable.buttonBox])}
+          onClick={toggleExpandable}>
           <div className={ccExpandable.title}>
             {typeof title === 'string' ? <span className={ccExpandable.titleType}>{title}</span> : title}
-            {chevron && (
-              <div
-                className={classNames({
-                  [ccExpandable.chevron]: true,
-                  [ccExpandable.chevronBox]: box,
-                  [ccExpandable.chevronNonBox]: !box,
-                })}>
-                {showChevronUp ? (
-                  <IconChevronUp16
-                    className={classNames({
-                      [ccExpandable.chevronTransform]: true,
-                      [ccExpandable.chevronCollapse]: !stateExpanded && showChevronUp,
-                    })}
-                  />
-                ) : (
-                  <IconChevronDown16
-                    className={classNames({
-                      [ccExpandable.chevronTransform]: true,
-                      [ccExpandable.chevronExpand]: stateExpanded && !showChevronUp,
-                    })}
-                  />
-                )}
-              </div>
-            )}
+            {chevron && <div className={classNames([ccExpandable.chevron, !box && ccExpandable.chevronNonBox])}>{chevronIcon}</div>}
           </div>
         </button>
       </UnstyledHeading>
       <ExpansionBehaviour animated={animated} stateExpanded={stateExpanded}>
         <div
-          className={classNames({
-            [contentClass || '']: true,
+          className={classNames(contentClass, {
             [ccBox.box]: box,
             [ccExpandable.paddingTop]: box && title,
           })}>
@@ -95,10 +97,7 @@ function ExpansionBehaviour({ animated, stateExpanded, children }) {
     <ExpandTransition show={stateExpanded}>{children}</ExpandTransition>
   ) : (
     <div
-      className={classNames({
-        [ccExpandable.expansion]: true,
-        [ccExpandable.expansionNotExpanded]: !stateExpanded,
-      })}
+      className={classNames([ccExpandable.expansion, !stateExpanded && ccExpandable.expansionNotExpanded])}
       data-testid="expandable-content"
       aria-hidden={!stateExpanded ? true : undefined}>
       {children}

--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -58,7 +58,7 @@ export function Expandable(props: ExpandableProps) {
     return stateExpanded ? <IconChevronUp16 className={upClasses} /> : <IconChevronDown16 className={downClasses} />;
   };
 
-  const contentClasses = classNames(contentClass, [box && ccBox.box, box && title && ccExpandable.paddingTop]);
+  const contentClasses = classNames(contentClass, [box && ccBox.box, (box || info) && title && ccExpandable.paddingTop]);
 
   return (
     <div {...rest} className={wrapperClasses}>

--- a/packages/expandable/src/component.tsx
+++ b/packages/expandable/src/component.tsx
@@ -41,21 +41,9 @@ export function Expandable(props: ExpandableProps) {
   };
 
   const chevronIcon = stateExpanded ? (
-    <IconChevronUp16
-      className={classNames([
-        ccExpandable.chevronTransform,
-        ccExpandable.elementsTransformChevronUpPart,
-        !stateExpanded && [ccExpandable.chevronCollapse, ccExpandable.elementsChevronUpCollapsePart],
-      ])}
-    />
+    <IconChevronUp16 className={classNames([ccExpandable.chevronTransform, !stateExpanded && ccExpandable.chevronCollapse])} />
   ) : (
-    <IconChevronDown16
-      className={classNames([
-        ccExpandable.chevronTransform,
-        ccExpandable.elementsTransformChevronDownPart,
-        stateExpanded && [ccExpandable.chevronExpand, ccExpandable.elementsChevronDownExpandPart],
-      ])}
-    />
+    <IconChevronDown16 className={classNames([ccExpandable.chevronTransform, stateExpanded && ccExpandable.chevronExpand])} />
   );
 
   return (

--- a/packages/expandable/src/props.tsx
+++ b/packages/expandable/src/props.tsx
@@ -22,12 +22,6 @@ export type ExpandableProps = {
   bleed?: boolean;
 
   /**
-   * Styles the box with light blue color
-   * @default false
-   */
-  info?: boolean;
-
-  /**
    * The state of the component, either true for expanded or false for closed.
    * @default false
    */

--- a/packages/expandable/stories/Expandable.stories.tsx
+++ b/packages/expandable/stories/Expandable.stories.tsx
@@ -33,16 +33,10 @@ export const BoxWithCustomIcon = () => (
   </Expandable>
 );
 
-export const InfoBox = () => (
-  <Expandable title="This is a title" box info>
-    <h2>I am expandable</h2>
-  </Expandable>
-);
-
 export const Controlled = () => {
   const [open, setOpen] = React.useState(false);
   return (
-    <Expandable title={open ? 'Open' : 'Closed'} box info onChange={setOpen}>
+    <Expandable title={open ? 'Open' : 'Closed'} box onChange={setOpen}>
       <h1>I am expandable</h1>
     </Expandable>
   );
@@ -51,7 +45,7 @@ export const Controlled = () => {
 export const NoChevron = () => {
   const [open, setOpen] = React.useState(false);
   return (
-    <Expandable title={open ? 'Open' : 'Closed'} box info chevron={false} onChange={setOpen}>
+    <Expandable title={open ? 'Open' : 'Closed'} box chevron={false} onChange={setOpen}>
       <h2>I am expandable</h2>
     </Expandable>
   );

--- a/packages/expandable/stories/Expandable.stories.tsx
+++ b/packages/expandable/stories/Expandable.stories.tsx
@@ -28,8 +28,7 @@ export const BoxWithCustomIcon = () => (
         <IconBag16 />
       </div>
     }
-    box
-    info>
+    box>
     <h2>I am expandable</h2>
   </Expandable>
 );
@@ -59,13 +58,13 @@ export const NoChevron = () => {
 };
 
 export const Animated = () => (
-  <Expandable title="Animated box" box info animated>
+  <Expandable title="Animated box" box animated>
     <h2>I am expandable</h2>
   </Expandable>
 );
 
 export const AnimatedExpanded = () => (
-  <Expandable title="Animated box" expanded box info animated>
+  <Expandable title="Animated box" expanded box animated>
     <h2>I am expandable</h2>
   </Expandable>
 );


### PR DESCRIPTION
## Description
This PR ensures no classes styling the same CSS properties are being set on the same HTML element in the `Expandable` component.

**Changes:**
- Renamed classNames in `Expandable` component.
- Refactored `Expandable` component
- Remove deprecated `info` prop
- Replace `paddingTop` with `contentWithTitle`

## How to test
Either link this branch with @warp-ds/css (`fix/cleanup-expandable-component` branch) or replace this for @warp-ds/css dependency in package.json: `github:warp-ds/css#component-classes-cleanup` with this  `github:warp-ds/css#fix/cleanup-expandable-component`