### PR TITLE
fix(badge): remove deprecated 'notification' example

### DIFF
--- a/packages/badge/src/props.tsx
+++ b/packages/badge/src/props.tsx
@@ -26,7 +26,7 @@ export interface BadgeProps {
    * Type of badge
    @default neutral
    */
-  variant?: 'neutral' | 'info' | 'positive' | 'warning' | 'negative' | 'disabled' | 'notification' | 'price';
+  variant?: 'neutral' | 'info' | 'positive' | 'warning' | 'negative' | 'disabled' | 'price';
 
   /**
    * Position of badge

--- a/packages/badge/stories/Badge.stories.tsx
+++ b/packages/badge/stories/Badge.stories.tsx
@@ -27,9 +27,6 @@ export const Variants = () => (
     <Badge as="li" variant="disabled">
       disabled badge
     </Badge>
-    <Badge as="li" variant="notification">
-      notification badge
-    </Badge>
     <Badge as="li" variant="price">
       price badge
     </Badge>


### PR DESCRIPTION
The notification variant of `Badge` is no longer supported in Warp and a corresponding token was removed from @warp-ds/css v2.0.0. This PR removes "notification" variant from `BadgeProps` interface and cleans up Storybook examples.