### PR TITLE
fix: lingui config for attention component

### DIFF
--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -47,11 +47,7 @@ const config: LinguiConfig = {
       path: 'packages/steps/src/locales/{locale}/messages',
     },
     {
-      include: ['packages/attention/src/**/*.{ts,tsx}'],
-      path: 'packages/attention/src/locales/{locale}/messages',
-    },
-    {
-      include: ['packages/_helpers/attention.tsx'],
+      include: ['packages/attention/src/**/*.{ts,tsx}', 'packages/_helpers/attention.tsx'],
       path: 'packages/attention/src/locales/{locale}/messages',
     },
     {

--- a/packages/attention/src/locales/da/messages.po
+++ b/packages/attention/src/locales/da/messages.po
@@ -17,17 +17,17 @@ msgstr ""
 "X-Crowdin-File-ID: 12398\n"
 "PO-Revision-Date: \n"
 
-#. Aria label for the close button in attention
-#. js-lingui-explicit-id
-#: packages/attention/src/component.tsx:186
-#~ msgid "attention.aria.close"
-#~ msgstr "Luk"
-
 #. Default screenreader message for callout speech bubble in the attention component
 #. js-lingui-explicit-id
 #: packages/_helpers/attention.tsx:66
 msgid "attention.aria.callout"
 msgstr "En grøn taleboble der introducerer noget nyt"
+
+#. Aria label for the close button in attention
+#. js-lingui-explicit-id
+#: packages/attention/src/component.tsx:186
+msgid "attention.aria.close"
+msgstr "Luk"
 
 #. Default screenreader message for highlighted speech bubble in the attention component
 #. js-lingui-explicit-id

--- a/packages/attention/src/locales/en/messages.po
+++ b/packages/attention/src/locales/en/messages.po
@@ -14,17 +14,17 @@ msgstr ""
 "Plural-Forms: \n"
 "X-Crowdin-SourceKey: msgstr\n"
 
-#. Aria label for the close button in attention
-#. js-lingui-explicit-id
-#: packages/attention/src/component.tsx:186
-#~ msgid "attention.aria.close"
-#~ msgstr "Close"
-
 #. Default screenreader message for callout speech bubble in the attention component
 #. js-lingui-explicit-id
 #: packages/_helpers/attention.tsx:66
 msgid "attention.aria.callout"
 msgstr "A green speech bubble introducing something new"
+
+#. Aria label for the close button in attention
+#. js-lingui-explicit-id
+#: packages/attention/src/component.tsx:186
+msgid "attention.aria.close"
+msgstr "Close"
 
 #. Default screenreader message for highlighted speech bubble in the attention component
 #. js-lingui-explicit-id

--- a/packages/attention/src/locales/fi/messages.po
+++ b/packages/attention/src/locales/fi/messages.po
@@ -17,17 +17,17 @@ msgstr ""
 "X-Crowdin-File-ID: 12398\n"
 "PO-Revision-Date: \n"
 
-#. Aria label for the close button in attention
-#. js-lingui-explicit-id
-#: packages/attention/src/component.tsx:186
-#~ msgid "attention.aria.close"
-#~ msgstr "Sulje"
-
 #. Default screenreader message for callout speech bubble in the attention component
 #. js-lingui-explicit-id
 #: packages/_helpers/attention.tsx:66
 msgid "attention.aria.callout"
 msgstr "Vihreä puhekupla, joka esittelee jotain uutta"
+
+#. Aria label for the close button in attention
+#. js-lingui-explicit-id
+#: packages/attention/src/component.tsx:186
+msgid "attention.aria.close"
+msgstr "Sulje"
 
 #. Default screenreader message for highlighted speech bubble in the attention component
 #. js-lingui-explicit-id

--- a/packages/attention/src/locales/nb/messages.po
+++ b/packages/attention/src/locales/nb/messages.po
@@ -17,17 +17,17 @@ msgstr ""
 "X-Crowdin-File-ID: 12398\n"
 "PO-Revision-Date: \n"
 
-#. Aria label for the close button in attention
-#. js-lingui-explicit-id
-#: packages/attention/src/component.tsx:186
-#~ msgid "attention.aria.close"
-#~ msgstr "Lukk"
-
 #. Default screenreader message for callout speech bubble in the attention component
 #. js-lingui-explicit-id
 #: packages/_helpers/attention.tsx:66
 msgid "attention.aria.callout"
 msgstr "Grønn taleboble som introduserer noe nytt"
+
+#. Aria label for the close button in attention
+#. js-lingui-explicit-id
+#: packages/attention/src/component.tsx:186
+msgid "attention.aria.close"
+msgstr "Lukk"
 
 #. Default screenreader message for highlighted speech bubble in the attention component
 #. js-lingui-explicit-id


### PR DESCRIPTION
Since we had 2 includes writing the same path for attention, this resulted in 1 translation becoming commented. This fixes that.