### PR TITLE
fix(attention): bump to latest version of @warp-ds/core dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
   "dependencies": {
     "@chbphone55/classnames": "2.0.0",
     "@lingui/core": "4.11.2",
-    "@warp-ds/core": "1.1.5",
+    "@warp-ds/core": "1.1.7",
     "@warp-ds/css": "2.0.0",
     "@warp-ds/icons": "2.1.0",
     "react-focus-lock": "2.12.1",

--- a/packages/attention/stories/Attention.stories.tsx
+++ b/packages/attention/stories/Attention.stories.tsx
@@ -15,7 +15,7 @@ export function Callout() {
       <Box info>
         <h1 aria-details="callout-bubbletext">I am a box full of info</h1>
       </Box>
-      <Attention callout placement="right" isShowing={true} className="ml-8">
+      <Attention callout placement="right" isShowing={true}>
         <p id="callout-bubbletext" style={{ width: 200 }}>
           I'm a callout because that box over there is new or something
         </p>
@@ -29,7 +29,7 @@ export function CalloutResettingRoleAndAriaLabel() {
       <Box info>
         <h1 aria-details="callout-reset-bubbletext">I am a box full of info</h1>
       </Box>
-      <Attention callout role="" aria-label="" placement="right" isShowing={true} className="ml-8">
+      <Attention callout role="" aria-label="" placement="right" isShowing={true}>
         <p id="callout-reset-bubbletext" role="img" style={{ width: 200 }}>
           I'm a callout speech bubble with resetted role and aria-label attributes pointing left.
         </p>
@@ -213,7 +213,7 @@ export function PopoverIconAsTargetEl() {
           popover
           placement="bottom-end"
           distance={0}
-          skidding={2}
+          skidding={10}
           targetEl={targetEl}
           isShowing={show}
           id="popover-icon-target-el-attention-example">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 4.11.2
         version: 4.11.2
       '@warp-ds/core':
-        specifier: 1.1.5
-        version: 1.1.5(@floating-ui/dom@1.6.10)
+        specifier: 1.1.7
+        version: 1.1.7(@floating-ui/dom@1.6.10)
       '@warp-ds/css':
         specifier: 2.0.0
         version: 2.0.0(@warp-ds/uno@2.0.0(unocss@0.62.0(postcss@8.4.41)(rollup@4.20.0)(vite@5.3.3(@types/node@20.14.10))))
@@ -2576,8 +2576,8 @@ packages:
   '@vitest/utils@2.0.2':
     resolution: {integrity: sha512-pxCY1v7kmOCWYWjzc0zfjGTA3Wmn8PKnlPvSrsA643P1NHl1fOyXj2Q9SaNlrlFE+ivCsxM80Ov3AR82RmHCWQ==}
 
-  '@warp-ds/core@1.1.5':
-    resolution: {integrity: sha512-rIM48g46USPV73S2nO8eY8u+w6eAWjMwjhpQ/R9cnMNuNTUQm9mn4JFs52BIge/a35UYdfxFPGIQH0qP0KrFFQ==}
+  '@warp-ds/core@1.1.7':
+    resolution: {integrity: sha512-yLHLDBVa/yXaxJq1wRkKuISA7W9aYl0h5sXvJXFxltNu0/rAZXJ2IVF757gjcwqOPTcixchvYm0AJT3qx1pSgw==}
     peerDependencies:
       '@floating-ui/dom': 1.6.x
 
@@ -10028,7 +10028,7 @@ snapshots:
       loupe: 3.1.1
       tinyrainbow: 1.2.0
 
-  '@warp-ds/core@1.1.5(@floating-ui/dom@1.6.10)':
+  '@warp-ds/core@1.1.7(@floating-ui/dom@1.6.10)':
     dependencies:
       '@floating-ui/dom': 1.6.10
 


### PR DESCRIPTION
Part of fixing JIRA issue: [WARP-607](https://nmp-jira.atlassian.net/browse/WARP-607)

**Changes:**
- Bump to latest version of `@warp-ds/core` to get the recent changes (where padding has been added to the attention-element)
- Remove margin-left from callout examples
- Adjust the distance for `Popover with icon as target element` example to align better