### PR TITLE
fix(packages): set @warp-ds/css peer-dependency to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@warp-ds/css": "2.0.0",
+    "@warp-ds/css": "2.0.1",
     "react": "18.x"
   },
   "scripts": {


### PR DESCRIPTION
Fixes warnings when installing the latest version of @warp-ds/react:
```bash
 WARN  Issues with peer dependencies found
.
├─┬ @warp-ds/react 2.0.2
│ └── ✕ unmet peer @warp-ds/css@2.0.0: found 2.0.1
```