### PR TITLE
fix(attention): move role and aria-label to attention-arrow wrapper

### DIFF
--- a/packages/attention/src/component.tsx
+++ b/packages/attention/src/component.tsx
@@ -173,12 +173,12 @@ export function Attention(props: AttentionProps) {
 
   return !props.callout && initialTargetEl === undefined ? null : (
     <div data-testid="attention-el" className={containerClasses} ref={attentionEl}>
-      <div
-        role={props.role === '' ? undefined : props.tooltip ? 'tooltip' : 'img'}
-        aria-label={ariaLabel === '' ? undefined : ariaLabel ?? defaultAriaLabel()}
-        className={wrapperClasses}
-        id={props.id}>
-        {!props.noArrow && <Arrow {...props} ref={arrowEl} direction={actualDirection} />}
+      <div className={wrapperClasses} id={props.id}>
+        <div
+          role={props.role === '' ? undefined : props.tooltip ? 'tooltip' : 'img'}
+          aria-label={ariaLabel === '' ? undefined : ariaLabel ?? defaultAriaLabel()}>
+          {!props.noArrow && <Arrow {...props} ref={arrowEl} direction={actualDirection} />}
+        </div>
         <div className={ccAttention.content}>{props.children}</div>
         {canClose && (
           <button


### PR DESCRIPTION
Fixes Jira issue: [WARP-651](https://nmp-jira.atlassian.net/browse/WARP-651)

**Changes include:**
- Move `role` and `aria-label` from the `div` wrapping the speech bubble to a `div` that is wrapping the attention `Arrow` component

