### PR TITLE
test: expose test-id on toggle item

### DIFF
--- a/packages/toggle/src/item.tsx
+++ b/packages/toggle/src/item.tsx
@@ -71,6 +71,7 @@ export function Item({
         value={label ? undefined : value ?? undefined}
         className={inputClassName}
         disabled={disabled}
+        data-testid={option?.value}
         {...props}
         onChange={(e) => props.onChange(label ? e.target.checked : option ? { label: option?.label, value: option?.value } : false)}
       />


### PR DESCRIPTION
Why this change?

This makes it easier for to do e2e testing of the toggles by exposing the value as `data-testid`. An attribute common to e2e libraries to handle selecting items.