### PR TITLE
fix(lingui): Move activateI18n outside of components

### DIFF
--- a/packages/attention/src/component.tsx
+++ b/packages/attention/src/component.tsx
@@ -57,7 +57,6 @@ export function Attention(props: AttentionProps) {
     ...rest
   } = props;
 
-
   const [actualDirection, setActualDirection] = useState(placement);
   // Don't show attention element before its position is computed on first render
   const [isVisible, setIsVisible] = useState<boolean | undefined>(false);

--- a/packages/attention/src/component.tsx
+++ b/packages/attention/src/component.tsx
@@ -35,6 +35,8 @@ const variantClasses = {
   },
 };
 
+activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
+
 export function Attention(props: AttentionProps) {
   let {
     noArrow,
@@ -55,7 +57,6 @@ export function Attention(props: AttentionProps) {
     ...rest
   } = props;
 
-  activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
   const [actualDirection, setActualDirection] = useState(placement);
   // Don't show attention element before its position is computed on first render

--- a/packages/breadcrumbs/src/component.tsx
+++ b/packages/breadcrumbs/src/component.tsx
@@ -18,7 +18,6 @@ activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 export const Breadcrumbs = (props: BreadcrumbsProps) => {
   const { children, className, ...rest } = props;
 
-
   const ariaLabel =
     props['aria-label'] ||
     i18n._({

--- a/packages/breadcrumbs/src/component.tsx
+++ b/packages/breadcrumbs/src/component.tsx
@@ -13,10 +13,11 @@ import { messages as nbMessages } from './locales/nb/messages.mjs';
 import { messages as svMessages } from './locales/sv/messages.mjs';
 import type { BreadcrumbsProps } from './props.js';
 
+activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
+
 export const Breadcrumbs = (props: BreadcrumbsProps) => {
   const { children, className, ...rest } = props;
 
-  activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
   const ariaLabel =
     props['aria-label'] ||

--- a/packages/button/src/component.tsx
+++ b/packages/button/src/component.tsx
@@ -15,6 +15,8 @@ import type { ButtonProps } from './props.js';
 
 const buttonVariants = ['primary', 'secondary', 'negative', 'utility', 'pill', 'link'] as const;
 
+activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
+
 export const Button = forwardRef<HTMLButtonElement | AnchorHTMLAttributes<HTMLAnchorElement>, ButtonProps>((props, ref) => {
   const { primary, secondary, negative, utility, quiet, small, link, href, pill, loading, disabled, fullWidth, ...rest } = props;
 
@@ -80,7 +82,6 @@ export const Button = forwardRef<HTMLButtonElement | AnchorHTMLAttributes<HTMLAn
     }
   };
 
-  activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
   const ariaValueTextLoading = i18n._({
     id: 'button.aria.loading',

--- a/packages/button/src/component.tsx
+++ b/packages/button/src/component.tsx
@@ -82,7 +82,6 @@ export const Button = forwardRef<HTMLButtonElement | AnchorHTMLAttributes<HTMLAn
     }
   };
 
-
   const ariaValueTextLoading = i18n._({
     id: 'button.aria.loading',
     message: 'Loading...',

--- a/packages/combobox/src/component.tsx
+++ b/packages/combobox/src/component.tsx
@@ -38,7 +38,6 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(({ id: pid, 
   const inputContainerRef = useRef<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
-
   // Options list open boolean
   const [isOpen, setOpen] = useState(false);
 

--- a/packages/combobox/src/component.tsx
+++ b/packages/combobox/src/component.tsx
@@ -29,6 +29,8 @@ import { createOptionsWithIdAndMatch, getAriaText } from './utils.js';
 const OPTION_CLASS_NAME = 'w-react-combobox-option';
 const MATCH_SEGMENTS_CLASS_NAME = 'w-react-combobox-match';
 
+activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
+
 export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(({ id: pid, ...props }, forwardRef) => {
   const id = useId(pid);
   const listboxId = `${id}-listbox`;
@@ -36,7 +38,6 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(({ id: pid, 
   const inputContainerRef = useRef<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
-  activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
   // Options list open boolean
   const [isOpen, setOpen] = useState(false);

--- a/packages/modal/src/component.tsx
+++ b/packages/modal/src/component.tsx
@@ -28,7 +28,6 @@ export const Modal = ({ 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelled
   const id = useId(props.id);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
-
   useEffect(
     () =>
       // Cleanup scroll lock if component unmounts before it receives an updated

--- a/packages/modal/src/component.tsx
+++ b/packages/modal/src/component.tsx
@@ -18,6 +18,8 @@ import { messages as nbMessages } from './locales/nb/messages.mjs';
 import { messages as svMessages } from './locales/sv/messages.mjs';
 import type { ModalProps } from './props.js';
 
+activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
+
 /**
  * A Modal dialog that renders on top of the page
  */
@@ -26,7 +28,6 @@ export const Modal = ({ 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelled
   const id = useId(props.id);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
-  activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
   useEffect(
     () =>

--- a/packages/pagination/src/Pagination.tsx
+++ b/packages/pagination/src/Pagination.tsx
@@ -41,9 +41,10 @@ export type PaginationProps = {
   style?: React.CSSProperties;
 } & Omit<React.PropsWithoutRef<JSX.IntrinsicElements['nav']>, 'children' | 'onChange'>;
 
+activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
+
 export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
   ({ currentPage, numPages, lastPage, createHref, className, onChange, noFollow, ...props }, ref) => {
-    activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
     if (!createHref) {
       throw new TypeError('createHref is undefined');

--- a/packages/pagination/src/Pagination.tsx
+++ b/packages/pagination/src/Pagination.tsx
@@ -45,7 +45,6 @@ activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
 export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
   ({ currentPage, numPages, lastPage, createHref, className, onChange, noFollow, ...props }, ref) => {
-
     if (!createHref) {
       throw new TypeError('createHref is undefined');
     }

--- a/packages/pill/src/component.tsx
+++ b/packages/pill/src/component.tsx
@@ -17,7 +17,6 @@ import type { PillProps } from './props.js';
 activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
 export function Pill(props: PillProps) {
-
   const buttonClasses = classNames(!props.canClose && props.className, [
     ccPill.button,
     ccPill.label,

--- a/packages/pill/src/component.tsx
+++ b/packages/pill/src/component.tsx
@@ -14,8 +14,9 @@ import { messages as nbMessages } from './locales/nb/messages.mjs';
 import { messages as svMessages } from './locales/sv/messages.mjs';
 import type { PillProps } from './props.js';
 
+activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
+
 export function Pill(props: PillProps) {
-  activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
   const buttonClasses = classNames(!props.canClose && props.className, [
     ccPill.button,

--- a/packages/select/src/component.tsx
+++ b/packages/select/src/component.tsx
@@ -21,7 +21,6 @@ activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 const setup = (props: SelectProps) => {
   const { className, invalid, id, hint, always, label, style, optional, readOnly, disabled, ...rest } = props;
 
-
   const helpId = hint ? `${id}__hint` : undefined;
 
   return {

--- a/packages/select/src/component.tsx
+++ b/packages/select/src/component.tsx
@@ -16,10 +16,11 @@ import { messages as nbMessages } from './locales/nb/messages.mjs';
 import { messages as svMessages } from './locales/sv/messages.mjs';
 import type { SelectProps } from './props.js';
 
+activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
+
 const setup = (props: SelectProps) => {
   const { className, invalid, id, hint, always, label, style, optional, readOnly, disabled, ...rest } = props;
 
-  activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
   const helpId = hint ? `${id}__hint` : undefined;
 

--- a/packages/steps/src/step.tsx
+++ b/packages/steps/src/step.tsx
@@ -58,7 +58,6 @@ export interface StepProps {
 activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
 export function Step(props: StepProps) {
-
   const { active, completed, children } = props;
   const StepsProps = useContext(StepsContext);
   const vertical = !StepsProps.horizontal;

--- a/packages/steps/src/step.tsx
+++ b/packages/steps/src/step.tsx
@@ -55,8 +55,9 @@ export interface StepProps {
   children: JSX.Element | JSX.Element[];
 }
 
+activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
+
 export function Step(props: StepProps) {
-  activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
   const { active, completed, children } = props;
   const StepsProps = useContext(StepsContext);

--- a/packages/textarea/src/component.tsx
+++ b/packages/textarea/src/component.tsx
@@ -15,6 +15,9 @@ import { messages as nbMessages } from './locales/nb/messages.mjs';
 import { messages as svMessages } from './locales/sv/messages.mjs';
 import { TextAreaProps } from './props.js';
 import useTextAreaHeight from './useTextAreaHeight.js';
+
+activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
+
 /**
  * A textarea component that automatically resizes as content changes.
  */
@@ -36,7 +39,6 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, f
     ...rest
   } = props;
 
-  activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
   const id = useId(providedId);
   const ref = useRef<HTMLTextAreaElement | null>(null);

--- a/packages/textarea/src/component.tsx
+++ b/packages/textarea/src/component.tsx
@@ -39,7 +39,6 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, f
     ...rest
   } = props;
 
-
   const id = useId(providedId);
   const ref = useRef<HTMLTextAreaElement | null>(null);
 

--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -33,7 +33,6 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, re
     ...rest
   } = props;
 
-
   const id = useId(providedId);
   const helpId = helpText ? `${id}__hint` : undefined;
   const isInvalid = invalid;

--- a/packages/textfield/src/component.tsx
+++ b/packages/textfield/src/component.tsx
@@ -15,6 +15,8 @@ import { messages as nbMessages } from './locales/nb/messages.mjs';
 import { messages as svMessages } from './locales/sv/messages.mjs';
 import { TextFieldProps } from './props.js';
 
+activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
+
 export const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, ref) => {
   const {
     className,
@@ -31,7 +33,6 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, re
     ...rest
   } = props;
 
-  activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
   const id = useId(providedId);
   const helpId = helpText ? `${id}__hint` : undefined;

--- a/packages/toggle/src/component.tsx
+++ b/packages/toggle/src/component.tsx
@@ -20,7 +20,6 @@ import type { ToggleEntry } from './props.js';
 activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
 function Title({ id, title, optional }) {
-
   return (
     <legend id={`${id}__title`} className={ccLabel.base}>
       {title}

--- a/packages/toggle/src/component.tsx
+++ b/packages/toggle/src/component.tsx
@@ -17,8 +17,9 @@ import { messages as svMessages } from './locales/sv/messages.mjs';
 import { ToggleProps } from './props.js';
 import type { ToggleEntry } from './props.js';
 
+activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
+
 function Title({ id, title, optional }) {
-  activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
   return (
     <legend id={`${id}__title`} className={ccLabel.base}>


### PR DESCRIPTION
This will ensure that translations are only loaded once, and will not create an infinite render-loop