### PR TITLE
fix: Combobox filtering for many options

### DIFF
--- a/packages/combobox/src/component.tsx
+++ b/packages/combobox/src/component.tsx
@@ -284,7 +284,7 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(({ id: pid, 
 
             return (
               <li
-                key={option.id}
+                key={option.key}
                 id={option.id}
                 role="option"
                 aria-selected={navigationOption?.id === option.id}

--- a/packages/combobox/src/props.ts
+++ b/packages/combobox/src/props.ts
@@ -1,10 +1,12 @@
 export type ComboboxOption = {
   value: string;
   label?: string;
+  key?: string;
 };
 
 export type OptionWithIdAndMatch = ComboboxOption & {
   id: string;
+  key: string;
   currentInputValue: string;
 };
 

--- a/packages/combobox/src/utils.ts
+++ b/packages/combobox/src/utils.ts
@@ -9,6 +9,7 @@ export function createOptionsWithIdAndMatch(options: ComboboxOption[], currentIn
   return options.map((option) => ({
     ...option,
     id: generateId(),
+    key: option.key || option.value,
     currentInputValue,
   }));
 }

--- a/tests/components/ComboBoxTest.tsx
+++ b/tests/components/ComboBoxTest.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, {useState} from 'react';
 
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { beforeEach, vi } from 'vitest';
@@ -64,6 +64,52 @@ describe('Combobox', () => {
     const option2 = screen.queryByText('Option 2');
     expect(option1).toBeInTheDocument();
     expect(option2).toBeNull();
+  });
+
+  it('filters options based on user input, with many options', () => {
+    const MAX_NUMBER = 300;
+    const props: ComboboxProps = {
+      id: 'combobox',
+      options: [...Array(MAX_NUMBER + 1).keys()].map((v) => ({ value: 'Option ' + v, key: 'key' + v })),
+      value: '',
+      label: 'Test Combobox',
+      onChange: vi.fn(),
+      onSelect: vi.fn(),
+    };
+
+    render(<ComboboxWrapper {...props} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'Option ' + MAX_NUMBER } });
+
+    for (let num = 0; num < MAX_NUMBER; ++num) {
+      const option = screen.queryByText('Option ' + num);
+      expect(option).not.toBeInTheDocument();
+    }
+    const option300 = screen.queryByText('Option ' + MAX_NUMBER);
+    expect(option300).toBeInTheDocument();
+  });
+
+  it('filters options based on user input, with many options, using value as a fallback key', () => {
+    const MAX_NUMBER = 300;
+    const props: ComboboxProps = {
+      id: 'combobox',
+      options: [...Array(MAX_NUMBER + 1).keys()].map((v) => ({ value: 'Option ' + v })),
+      value: '',
+      label: 'Test Combobox',
+      onChange: vi.fn(),
+      onSelect: vi.fn(),
+    };
+
+    render(<ComboboxWrapper {...props} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'Option ' + MAX_NUMBER } });
+
+    for (let num = 0; num < MAX_NUMBER; ++num) {
+      const option = screen.queryByText('Option ' + num);
+      expect(option).not.toBeInTheDocument();
+    }
+    const option300 = screen.queryByText('Option ' + MAX_NUMBER);
+    expect(option300).toBeInTheDocument();
   });
 
   it('selects an option on click', async () => {

--- a/tests/components/__snapshots__/SliderTest.tsx.snap
+++ b/tests/components/__snapshots__/SliderTest.tsx.snap
@@ -9,7 +9,7 @@ exports[`Slider > renders correctly 1`] = `
       class="absolute s-bg-disabled-subtle h-4 top-20 rounded-4 w-full "
     />
     <div
-      class="absolute h-6 top-[19px] rounded-4 s-bg-primary"
+      class="absolute h-6 top-[1.92rem] rounded-4 s-bg-primary"
       style="left: 0px;"
     />
     <div


### PR DESCRIPTION
fixing broken filtering in the Combobox when there are many (e.g. >= 170) options available.
