### PR TITLE
fix: nullable children inside <Box/>

### DIFF
--- a/packages/box/src/props.tsx
+++ b/packages/box/src/props.tsx
@@ -4,7 +4,7 @@ export interface BoxProps {
   /**
    * Expand element children
    */
-  children: JSX.Element | JSX.Element[];
+  children: React.ReactNode;
 
   /**
    * Additional classes to include

--- a/tests/components/BoxTest.tsx
+++ b/tests/components/BoxTest.tsx
@@ -14,6 +14,16 @@ describe('Box', () => {
     expect(screen.getByRole('region')).toBeInTheDocument();
     expect(screen.getByRole('region')).toHaveTextContent('Test Box');
   });
+  test('renders Box component with nullable children', () => {
+    const conditionalVariable = false;
+    render(
+      <Box bleed={true} info={true}>
+        Test Box
+        {conditionalVariable && <div>abc123</div>}
+      </Box>,
+    );
+    expect(screen.getByText('abc123')).toBeInTheDocument();
+  });
 
   test('renders Box component with correct classes when bleed is true', () => {
     const { container } = render(<Box bleed={true}>Test Box</Box>);


### PR DESCRIPTION
Error scenario:
`<Box>{aBooleanVariable && <div>abc</div>}</Box>`
Error message:
```
error TS2322: Type 'false | Element' is not assignable to type 'Element'.
  Type 'boolean' is not assignable to type 'ReactElement<any, any>'.

175     {!isLightLaunch && <div>abc</div>}

```
