### PR TITLE
fix: update FocusLock import path to use the default export

### DIFF
--- a/packages/modal/src/component.tsx
+++ b/packages/modal/src/component.tsx
@@ -5,7 +5,7 @@ import { i18n } from '@lingui/core';
 import { modal as ccModal } from '@warp-ds/css/component-classes';
 import IconArrowLeft16 from '@warp-ds/icons/react/arrow-left-16';
 import IconClose16 from '@warp-ds/icons/react/close-16';
-import FocusLock from 'react-focus-lock/dist/es2015/Lock.js';
+import FocusLock from 'react-focus-lock';
 import { setup, teardown } from 'scroll-doctor';
 
 import { activateI18n } from '../../i18n.js';
@@ -55,6 +55,7 @@ export const Modal = ({ 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelled
   if (!props.open) return <></>;
 
   return (
+    //@ts-ignore
     <FocusLock>
       <div onClick={props.onDismiss} className={classNames(props.className, ccModal.backdrop)} style={{ ...props.style }}>
         <div


### PR DESCRIPTION
Second attempt to fix FocusLock error.
Generates typescript error `"FocusLock" cannot be used as a JSX component.`,
but according to [docs](https://www.npmjs.com/package/react-focus-lock) it should be valid –
runs in Storybook.