### PR TITLE
fix: build Eik asset for React 19 users

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -8,6 +8,7 @@ import esbuild from 'esbuild';
 const versions = new Map([
   ['17', 'v2'],
   ['18', 'v3'],
+  ['19', 'v19'],
 ]);
 
 const version = process.argv[2];

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "scripts": {
     "build-storybook": "lingui compile && storybook build && touch ./storybook-static/.nojekyll",
     "build:clean": "rm -rf dist",
-    "build:eik": "node esbuild.js 17 && node esbuild.js 18",
+    "build:eik": "node esbuild.js 17 && node esbuild.js 18 && node esbuild.js 19",
     "build:npm": "node build.js",
     "build:types": "tsc && sed 's+declare module \"index\"+declare module \"@warp-ds/react\"+g' ./dist/npm/index.d.ts > ./dist/npm/updated.d.ts && mv ./dist/npm/updated.d.ts ./dist/npm/index.d.ts",
     "build": "pnpm run build:clean && lingui compile && pnpm run build:npm && pnpm run build:eik && pnpm run build:types",


### PR DESCRIPTION
Build a version with import mapping pointing to the v19 version of React.

Once this is on Eik we can make an import map for React v19 users.