### PR TITLE
fix: use label for input field preview if available

### DIFF
--- a/packages/combobox/src/component.tsx
+++ b/packages/combobox/src/component.tsx
@@ -71,7 +71,7 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(({ id: pid, 
     ...rest
   } = props;
 
-  const navigationValueOrInputValue = navigationOption?.value || value;
+  const navigationValueOrInputValue = navigationOption?.label || navigationOption?.value || value;
 
   const optionClasses = (option: OptionWithIdAndMatch) =>
     classNames(


### PR DESCRIPTION
when navigating the combobox options with the keyboard, the input field would use the value for preview. this fix uses the label if it exists, before using the value

Bug in action on [FINN Mobility search](https://www.finn.no/mobility/search/car?registration_class=1):
<img width="315" height="486" alt="image" src="https://github.com/user-attachments/assets/f10824b7-abbe-4424-a235-e56d5d472664" />
