### PR TITLE
fix: use label for input field preview if available

### DIFF
--- a/packages/combobox/src/component.tsx
+++ b/packages/combobox/src/component.tsx
@@ -24,7 +24,7 @@ import { messages as fiMessages } from './locales/fi/messages.mjs';
 import { messages as nbMessages } from './locales/nb/messages.mjs';
 import { messages as svMessages } from './locales/sv/messages.mjs';
 import type { ComboboxProps, OptionWithIdAndMatch } from './props.js';
-import { createOptionsWithIdAndMatch, getAriaText } from './utils.js';
+import { createOptionsWithIdAndMatch, getAriaText, getSelectedOptionText } from './utils.js';
 
 const OPTION_CLASS_NAME = 'w-react-combobox-option';
 const MATCH_SEGMENTS_CLASS_NAME = 'w-react-combobox-match';
@@ -71,7 +71,7 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(({ id: pid, 
     ...rest
   } = props;
 
-  const navigationValueOrInputValue = navigationOption?.value || value;
+  const navigationValueOrInputValue = getSelectedOptionText(navigationOption) || value;
 
   const optionClasses = (option: OptionWithIdAndMatch) =>
     classNames(

--- a/packages/combobox/src/utils.ts
+++ b/packages/combobox/src/utils.ts
@@ -34,3 +34,15 @@ export function getAriaText(options: OptionWithIdAndMatch[], value: string) {
 
   return filteredOptionsByInputValue.length ? pluralResults : noResults;
 }
+
+export function getSelectedOptionText(navigationOption: OptionWithIdAndMatch | null) {
+  if (!navigationOption) {
+    return '';
+  }
+
+  if (typeof navigationOption.label === 'string' || typeof navigationOption.label === 'number') {
+    return navigationOption.label.toString();
+  }
+
+  return navigationOption.value;
+}


### PR DESCRIPTION
Add a utility function to be able to use more rules to calculate the title: only get the label if it's convertible to text

Giving another stab at https://github.com/warp-ds/react/pull/327 